### PR TITLE
Bump python_requires to 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setuptools.setup(
     entry_points={
         'console_scripts': ['criticality_score=criticality_score.run:main'],
     },
-    python_requires='>=3',
+    python_requires='>=3.6',
     zip_safe=False,
 )


### PR DESCRIPTION
The criticality_score is using some high version feature, such as `print(f'')` Formatted string literals[1], which is added in pyhton 3.6.
That means the script would be break down in the python version < 3.6.

This patch bump the python_requires to 3.6 to make sure the script works well.

[1] https://docs.python.org/3.6/reference/lexical_analysis.html#formatted-string-literals