### PR TITLE
Add logging to generate script

### DIFF
--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -18,6 +18,7 @@ import csv
 import os
 import sys
 import time
+import logging
 
 from . import run
 
@@ -117,6 +118,17 @@ def main():
 
     args = parser.parse_args()
 
+    # logging
+    log_filename = os.path.join(args.output_dir, 'generate.log')
+    logging.basicConfig(filename=log_filename, filemode="w", level=logging.WARNING)
+
+    # console handler
+    console = logging.StreamHandler()
+    console.setLevel(logging.ERROR)
+    logging.getLogger("").addHandler(console)
+
+    logger = logging.getLogger(__name__)
+
     # GitHub search can return incomplete results in a query, so try it multiple
     # times to avoid missing urls.
     repo_urls = set()
@@ -135,8 +147,9 @@ def main():
                 output = run.get_repository_stats(repo)
                 break
             except Exception as exp:
-                print(
-                    f'Exception occurred when reading repo: {repo_url}\n{exp}')
+                msg = f'Exception occurred when reading repo: {repo_url}\n{exp}'
+                print(msg)
+                logger.exception(msg)
         if not output:
             continue
         if not header:

--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -93,17 +93,15 @@ def get_github_repo_urls_for_language(urls, sample_size, github_lang=None):
 
     return urls
 
-
-def main():
-    # logging
-    log_filename = os.path.join('output', 'generate.log')
+def initialize_logging_handlers(output_dir):
+    log_filename = os.path.join(output_dir, 'output.log')
     logging.basicConfig(filename=log_filename, filemode='w', level=logging.INFO)
 
-    # console handler
     console = logging.StreamHandler()
     console.setLevel(logging.INFO)
-    logging.getLogger('').addHandler(console)
+    logging.getLogger('').addHandler(console)    
 
+def main():
     parser = argparse.ArgumentParser(
         description=
         'Generate a sorted criticality score list for particular language(s).')
@@ -128,6 +126,8 @@ def main():
         help="Number of projects to analyze (in descending order of stars).")
 
     args = parser.parse_args()
+
+    initialize_logging_handlers(args.output_dir)
 
     # GitHub search can return incomplete results in a query, so try it multiple
     # times to avoid missing urls.


### PR DESCRIPTION
When we run generate script for large number of repos, it becomes difficult to follow the exceptions.
Not sure what are the best practices but I added basic logging by following this example. Looks like it's doing the job:
https://stackoverflow.com/questions/15474095/writing-a-log-file-from-python-program

As usual, feel free to accept/discard it
