### PR TITLE
Update format of generate script console output

### DIFF
--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -136,9 +136,8 @@ def main():
         logger.info(f'Finding repos (round {rnd}):')
         repo_urls.update(get_github_repo_urls(args.sample_size, args.language))
 
-    csv_writer = csv.writer(sys.stdout)
-    header = None
     stats = []
+    index = 1
     for repo_url in repo_urls:
         output = None
         for _ in range(3):
@@ -150,11 +149,9 @@ def main():
                 logger.exception(f'Exception occurred when reading repo: {repo_url}\n{exp}')
         if not output:
             continue
-        if not header:
-            header = output.keys()
-            csv_writer.writerow(header)
-        csv_writer.writerow(output.values())
+        logger.info(f"{index} - {output['name']} - {output['url']} - {output['criticality_score']}")
         stats.append(output)
+        index += 1
 
     languages = '_'.join(args.language) if args.language else 'all'
     languages = languages.replace('+', 'plus').replace('c#', 'csharp')
@@ -162,6 +159,7 @@ def main():
                                    f'{languages}_top_{args.count}.csv')
     with open(output_filename, 'w') as file_handle:
         csv_writer = csv.writer(file_handle)
+        header = output.keys()
         csv_writer.writerow(header)
         for i in sorted(stats,
                         key=lambda i: i['criticality_score'],


### PR DESCRIPTION
When running generate script with large numbers, there's no way of knowing how many repos are processed and how many left to go. So, I wanted to display an index for each line. Since I started playing with it, I changed the output format a little.

**Current output**

```shell

name,url,language,created_since,updated_since,contributor_count,org_count,commit_frequency,recent_releases_count,updated_issues_count,closed_issues_count,comment_frequency,dependents_count,criticality_score
Hacky,https://github.com/eliaskg/Hacky,Objective-C,97,84,4,2,0.0,0,0,0,0,0,0.10185
flame.js,https://github.com/flamejs/flame.js,JavaScript,107,57,34,5,0.0,0,0,0,0,2,0.22108
```

**New output**: no header, each line only shows index, name, url, score

```shell
0 - iglo - https://github.com/subosito/iglo - 0.1077
1 - Hacky - https://github.com/eliaskg/Hacky - 0.10185
```

**Alternatively**, if we still want to see all the fields, I can keep the old format but only add the index like this:

```shell
name,url,language,created_since,updated_since,contributor_count,org_count,commit_frequency,recent_releases_count,updated_issues_count,closed_issues_count,comment_frequency,dependents_count,criticality_score
0 - Hacky,https://github.com/eliaskg/Hacky,Objective-C,97,84,4,2,0.0,0,0,0,0,0,0.10185
1 - flame.js,https://github.com/flamejs/flame.js,JavaScript,107,57,34,5,0.0,0,0,0,0,2,0.22108
```

Let me know what you think