### PR TITLE
Make sure criticality_score between 0 and 1

### DIFF
--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -456,6 +456,9 @@ def get_repository_stats(repo, additional_params=None):
                  DEPENDENTS_COUNT_WEIGHT)) + additional_params_score) /
         total_weight, 5)
 
+    # Make sure score between 0 (least-critical) and 1 (most-critical). 
+    criticality_score = max(min(criticality_score, 1), 0)
+
     result_dict['criticality_score'] = criticality_score
     return result_dict
 


### PR DESCRIPTION
Due to the negative weight, the numerator of score may be greater than the denominator, that means the score would be greater than 1. And the numerator may be also less than 0, that means final score would be less than 0.

So in this patch, we set the finall criticality_score between 0 (least-critical) and 1 (most-critical).

Close: https://github.com/ossf/criticality_score/issues/68