### PR TITLE
Add .ropeproject folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
+
+# Rope project settings
+.ropeproject


### PR DESCRIPTION
I'm using Visual Studio Code to edit the project.
At some point, it created this ".ropeproject" folder, and apparently it can be ignored:
https://github.com/github/gitignore/blob/master/Python.gitignore
