### PR TITLE
Fix regex to cover '1 commit result' case

### DIFF
--- a/criticality_score/constants.py
+++ b/criticality_score/constants.py
@@ -45,4 +45,4 @@ RELEASE_LOOKBACK_DAYS = 365
 FAIL_RETRIES = 7
 
 # Regex to match dependents count.
-DEPENDENTS_REGEX = re.compile(b'.*[^0-9,]([0-9,]+).*commit results', re.DOTALL)
+DEPENDENTS_REGEX = re.compile(b'.*[^0-9,]([0-9,]+).*commit result', re.DOTALL)


### PR DESCRIPTION
Current regex doesn't cover '1 commit result' case, that means if we
get only 1 commit result, the dependent number will be set to 0.

This patch try to fix it by use '* commit result' to match 'n commit results'
and '1 commit result' case.