### PR TITLE
Handle not found cases

### DIFF
--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -143,6 +143,9 @@ def main():
         for _ in range(3):
             try:
                 repo = run.get_repository(repo_url)
+                if not repo:
+                    logger.error(f'Repo not found: {repo_url}')
+                    break
                 output = run.get_repository_stats(repo)
                 break
             except Exception as exp:

--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -523,14 +523,24 @@ def get_repository(url):
     parsed_url = urllib.parse.urlparse(url)
     repo_url = parsed_url.path.strip('/')
     if parsed_url.netloc.endswith('github.com'):
-        repo = GitHubRepository(get_github_auth_token().get_repo(repo_url))
-        return repo
+        repo = None
+        try:
+            repo = get_github_auth_token().get_repo(repo_url)
+        except github.GithubException as exp:
+            if exp.status == 404:
+                return None
+        return GitHubRepository(repo)
     if 'gitlab' in parsed_url.netloc:
+        repo = None
         host = parsed_url.scheme + '://' + parsed_url.netloc
         token_obj = get_gitlab_auth_token(host)
         repo_url_encoded = urllib.parse.quote_plus(repo_url)
-        repo = GitLabRepository(token_obj.projects.get(repo_url_encoded))
-        return repo
+        try:
+            repo = token_obj.projects.get(repo_url_encoded)
+        except gitlab.exceptions.GitlabGetError as exp:
+            if exp.response_code == 404:
+                return None
+        return GitLabRepository(repo)
 
     raise Exception('Unsupported url!')
 
@@ -557,6 +567,9 @@ def main():
 
     args = parser.parse_args()
     repo = get_repository(args.repo)
+    if not repo:
+        print(f'Repo not found: {args.repo}', file=sys.stderr)
+        return
     output = get_repository_stats(repo, args.params)
     if args.format == 'default':
         for key, value in output.items():


### PR DESCRIPTION
I was looking into whether we can improve handling "deleted/non-existing repos" cases:
* It shows a "Repo not found" message, instead of the exception
* In "generate" script, if the repo is not found, it doesn't continue with the retries

Current output for GitHub in "not found" case:

```shell
Traceback (most recent call last):
  File "..\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "..\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "..\criticality_score\criticality_score\run.py", line 584, in <module>
    main()
  File "..\criticality_score\criticality_score\run.py", line 564, in main
    repo = get_repository(args.repo)
  File "..\criticality_score\criticality_score\run.py", line 526, in get_repository
    repo = get_github_auth_token().get_repo(repo_url)
  File "..\Python39\lib\site-packages\github\MainClass.py", line 345, in get_repo
    headers, data = self.__requester.requestJsonAndCheck(
  File "..\Python39\lib\site-packages\github\Requester.py", line 315, in requestJsonAndCheck
    return self.__check(
  File "..\Python39\lib\site-packages\github\Requester.py", line 340, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/repos#get-a-repository"}
```

New output:
```shell
Repo not found: https://github.com/x/x
```