### PR TITLE
Add logger to run script

### DIFF
--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -580,7 +580,7 @@ def main():
     args = parser.parse_args()
     repo = get_repository(args.repo)
     if not repo:
-        print(f'Repo not found: {args.repo}', file=sys.stderr)
+        logger.error(f'Repo not found: {args.repo}')
         return
     output = get_repository_stats(repo, args.params)
     if args.format == 'default':

--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -17,6 +17,7 @@ import argparse
 import csv
 import datetime
 import json
+import logging
 import math
 import os
 import sys
@@ -29,6 +30,8 @@ import gitlab
 import requests
 
 from .constants import *  # pylint: disable=wildcard-import
+
+logger = logging.getLogger()
 
 _CACHED_GITHUB_TOKEN = None
 _CACHED_GITHUB_TOKEN_OBJ = None
@@ -393,8 +396,7 @@ def get_repository_stats(repo, additional_params=None):
                 int(i) for i in additional_param.split(':')
             ]
         except ValueError:
-            print('Parameter value in bad format: ' + additional_param,
-                  file=sys.stderr)
+            logger.error('Parameter value in bad format: ' + additional_param)
             sys.exit(1)
         additional_params_total_weight += weight
         additional_params_score += get_param_score(value, max_threshold,
@@ -496,8 +498,7 @@ def get_github_auth_token():
             _CACHED_GITHUB_TOKEN_OBJ = token_obj
             return token_obj
 
-    print(f'Rate limit exceeded, sleeping till reset: {round(min_wait_time / 60, 1)} minutes.',
-          file=sys.stderr)
+    logger.warning(f'Rate limit exceeded, sleeping till reset: {round(min_wait_time / 60, 1)} minutes.')
     time.sleep(min_wait_time)
     return token_obj
 
@@ -509,7 +510,7 @@ def get_gitlab_auth_token(host):
         token_obj = gitlab.Gitlab(host, gitlab_auth_token)
         token_obj.auth()
     except gitlab.exceptions.GitlabAuthenticationError:
-        print("Auth token didn't work, trying un-authenticated. "
+        logger.info("Auth token didn't work, trying un-authenticated. "
               "Some params like comment_frequency will not work.")
         token_obj = gitlab.Gitlab(host)
     return token_obj
@@ -535,6 +536,15 @@ def get_repository(url):
     raise Exception('Unsupported url!')
 
 
+def initialize_logging_handlers():
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger('').handlers.clear()
+
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    logging.getLogger('').addHandler(console)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Gives criticality score for an open source project')
@@ -555,14 +565,16 @@ def main():
         help='Additional parameters in form <value>:<weight>:<max_threshold>',
         required=False)
 
+    initialize_logging_handlers()
+
     args = parser.parse_args()
     repo = get_repository(args.repo)
     output = get_repository_stats(repo, args.params)
     if args.format == 'default':
         for key, value in output.items():
-            print(f'{key}: {value}')
+            logger.info(f'{key}: {value}')
     elif args.format == 'json':
-        print(json.dumps(output, indent=4))
+        logger.info(json.dumps(output, indent=4))
     elif args.format == 'csv':
         csv_writer = csv.writer(sys.stdout)
         csv_writer.writerow(output.keys())


### PR DESCRIPTION
I tried to add "logger" to run script before but somehow I couldn't make it work. Now it turned out to be a very simple one 🤷‍♂️

I'm just not sure about moving "initialize_logging_handlers" function to a generic place.

It's very similar to the one in "generate" script:

**run**
```python
def initialize_logging_handlers():
    logging.basicConfig(level=logging.INFO)
    logging.getLogger('').handlers.clear()

    console = logging.StreamHandler()
    console.setLevel(logging.INFO)
    logging.getLogger('').addHandler(console)
```

**generate**
```python
def initialize_logging_handlers(output_dir):
    log_filename = os.path.join(output_dir, 'output.log')
    logging.basicConfig(filename=log_filename, filemode='w', level=logging.INFO)

    console = logging.StreamHandler()
    console.setLevel(logging.INFO)
    logging.getLogger('').addHandler(console)
```
