### PR TITLE
Handle empty repo case

### DIFF
--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -146,8 +146,6 @@ def main():
                     logger.error(f'Repo is not found: {repo_url}')
                     break
                 output = run.get_repository_stats(repo)
-                if not output:
-                    logger.error(f'Repo is empty: {repo_url}')
                 break
             except Exception as exp:
                 logger.exception(f'Exception occurred when reading repo: {repo_url}\n{exp}')

--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -143,7 +143,7 @@ def main():
             try:
                 repo = run.get_repository(repo_url)
                 if not repo:
-                    logger.error(f'Repo not found: {repo_url}')
+                    logger.error(f'Repo is empty or not found: {repo_url}')
                     break
                 output = run.get_repository_stats(repo)
                 break
@@ -155,6 +155,8 @@ def main():
         stats.append(output)
         index += 1
 
+    if len(stats) == 0:
+        return
     languages = '_'.join(args.language) if args.language else 'all'
     languages = languages.replace('+', 'plus').replace('c#', 'csharp')
     output_filename = os.path.join(args.output_dir,

--- a/criticality_score/generate.py
+++ b/criticality_score/generate.py
@@ -143,9 +143,11 @@ def main():
             try:
                 repo = run.get_repository(repo_url)
                 if not repo:
-                    logger.error(f'Repo is empty or not found: {repo_url}')
+                    logger.error(f'Repo is not found: {repo_url}')
                     break
                 output = run.get_repository_stats(repo)
+                if not output:
+                    logger.error(f'Repo is empty: {repo_url}')
                 break
             except Exception as exp:
                 logger.exception(f'Exception occurred when reading repo: {repo_url}\n{exp}')

--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -45,8 +45,9 @@ PARAMS = [
 
 class Repository:
     """General source repository."""
-    def __init__(self, repo):
+    def __init__(self, repo, last_commit):
         self._repo = repo
+        self._last_commit = last_commit
         self._created_since = None
 
     @property
@@ -59,6 +60,10 @@ class Repository:
 
     @property
     def language(self):
+        raise NotImplementedError
+
+    @property
+    def last_commit(self):
         raise NotImplementedError
 
     @property
@@ -136,6 +141,10 @@ class GitHubRepository(Repository):
     def language(self):
         return self._repo.language
 
+    @property
+    def last_commit(self):
+        return self._last_commit
+
     def get_first_commit_time(self):
         def _parse_links(response):
             link_string = response.headers.get('Link')
@@ -189,8 +198,7 @@ class GitHubRepository(Repository):
 
     @property
     def updated_since(self):
-        last_commit = self._repo.get_commits()[0]
-        last_commit_time = last_commit.commit.author.date
+        last_commit_time = self.last_commit.commit.author.date
         difference = datetime.datetime.utcnow() - last_commit_time
         return round(difference.days / 30)
 
@@ -294,6 +302,10 @@ class GitLabRepository(Repository):
         return (max(languages, key=languages.get)).lower()
 
     @property
+    def last_commit(self):
+        return self.last_commit
+
+    @property
     def created_since(self):
         creation_time = self._date_from_string(self._repo.created_at)
         commit = None
@@ -308,10 +320,9 @@ class GitLabRepository(Repository):
 
     @property
     def updated_since(self):
-        last_commit = self._repo.commits.list()[0]
         difference = datetime.datetime.now(
             datetime.timezone.utc) - self._date_from_string(
-                last_commit.created_at)
+                self.last_commit.created_at)
         return round(difference.days / 30)
 
     @property
@@ -528,27 +539,30 @@ def get_repository(url):
     repo_url = parsed_url.path.strip('/')
     if parsed_url.netloc.endswith('github.com'):
         repo = None
+        last_commit = None
         try:
             repo = get_github_auth_token().get_repo(repo_url)
-            # Validate whether repo is empty; if it's empty, calling totalCount throws a 409 exception
-            total_commits = repo.get_commits().totalCount
+            last_commit = repo.get_commits()[0]
         except github.GithubException as exp:
             if exp.status == 404 or exp.status == 409:
                 return None
-        return GitHubRepository(repo)
+        return GitHubRepository(repo, last_commit)
     if 'gitlab' in parsed_url.netloc:
         repo = None
+        last_commit = None
         host = parsed_url.scheme + '://' + parsed_url.netloc
         token_obj = get_gitlab_auth_token(host)
         repo_url_encoded = urllib.parse.quote_plus(repo_url)
         try:
             repo = token_obj.projects.get(repo_url_encoded)
-            if len(repo.commits.list()) == 0:
+            commits = repo.commits.list()
+            if len(commits) == 0:
                 return None
+            last_commit = commits[0]
         except gitlab.exceptions.GitlabGetError as exp:
             if exp.response_code == 404:
                 return None
-        return GitLabRepository(repo)
+        return GitLabRepository(repo, last_commit)
 
     raise Exception('Unsupported url!')
 


### PR DESCRIPTION
When I was running the script, I bumped into these repos that they fall into the filter due to high number of stars but they're actually empty and the script throws an exception:
https://github.com/fossasia/libregraphics.asia
https://github.com/libredesktop/libredesktop-events
https://github.com/libredesktop/libredesktop-project-list
https://github.com/libredesktop/LibreDesktop-Specs
https://github.com/meilix/arch-meilix
https://github.com/meilix/deb-meilix
https://github.com/meilix/meilix-addons
https://github.com/meilix/meilix-art
https://github.com/meilix/meilix-connect
https://github.com/meilix/meilix-web
https://github.com/susiai/susi_partners
https://github.com/susiai/susi_sdk
https://github.com/ascoders/blog
https://github.com/bigdongdongCLUB/newGCP
https://github.com/koush/support-wiki
https://github.com/mariobehling/ai-packages
https://github.com/mariobehling/mb-sandbox
https://github.com/meilix/meilix-docs
https://github.com/paulirish/devtools-addons
https://github.com/QingDaoIT/BlackList
https://github.com/zhengzhouqiuzhi/zhengzhouqiuzhi

To handle it, for GitLab, checking the commits length was enough:
```python
if len(repo.commits.list()) == 0:
```

For GitHub, I couldn't find any proper way to understand whether the repo is empty. When we call "get_commits().totalCount", it already throws an exception. What I did is to force it to throw the exception by assigning "totalCount" to an unused variable (I could do it by printing the value as well?). Not an ideal solution, so let me know what you think.

```python
try:
	repo = get_github_auth_token().get_repo(repo_url)
	# Validate whether repo is empty; if it's empty, calling totalCount throws a 409 exception
	total_commits = repo.get_commits().totalCount
except github.GithubException as exp:
	if exp.status == 404 or exp.status == 409:
		return None
return GitHubRepository(repo)
```

Another remark is that we're spending one more request from our rate limit when calling "get_commits()" to make this validation. I only tested this for GitHub, but I'm assuming it's the same for GitLab as well.

Alternatively, we can make all these calls before initializing the repo, do the validations, and pass them to repo object as arguments? This would also help us reducing the number of call to the API, but making these changes would take some time.

To be able to test my changes, I created empty repos on both GitHub & GitLab btw:
https://github.com/coni2k/empty-repo
https://gitlab.com/coni2k/empty-repo

Last, I also added this bit to "generate" script. Otherwise it fails when there are no processed repos:
```python
if len(stats) == 0:
    return
```