### PR TITLE
Handle get_tags exception

### DIFF
--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -259,7 +259,9 @@ class GitHubRepository(Repository):
             try:
                 total_tags = self._repo.get_tags().totalCount
             except Exception:
+                # Very large number of tags, i.e. 5000+. Cap at 26.
                 logger.error(f'get_tags is failed: {self._repo.url}')
+                return RECENT_RELEASES_THRESHOLD
             total = round(
                 (total_tags / days_since_creation) * RELEASE_LOOKBACK_DAYS)
         return total

--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -255,7 +255,11 @@ class GitHubRepository(Repository):
             days_since_creation = self.created_since * 30
             if not days_since_creation:
                 return 0
-            total_tags = self._repo.get_tags().totalCount
+            total_tags = 0
+            try:
+                total_tags = self._repo.get_tags().totalCount
+            except Exception:
+                logger.error(f'get_tags is failed: {self._repo.url}')
             total = round(
                 (total_tags / days_since_creation) * RELEASE_LOOKBACK_DAYS)
         return total


### PR DESCRIPTION
When we request `get_tags` for this repo, GitHub API throws an exception (interestingly, this was the only repo that was persistent in throwing an exception):
https://github.com/hortonworks/cloudbreak

```shell
python -u -m criticality_score.run --repo github.com/hortonworks/cloudbreak
```

It has 8,707 tags, so probably that's a large number for the API to process.

The only detail is that in catch block of "contributors", you return "10" as a default value. Should I set a similar default value for tags as well?