### PR TITLE
Add Watchers/Description Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,19 @@ $ criticality_score --repo github.com/kubernetes/kubernetes
 name: kubernetes
 url: https://github.com/kubernetes/kubernetes
 language: Go
-created_since: 79
+description: Production-Grade Container Scheduling and Management
+created_since: 87
 updated_since: 0
-contributor_count: 3664
+contributor_count: 3999
+watchers_count: 79583
 org_count: 5
-commit_frequency: 102.7
-recent_releases_count: 76
-closed_issues_count: 2906
-updated_issues_count: 5136
-comment_frequency: 5.7
-dependents_count: 407254
-criticality_score: 0.9862
+commit_frequency: 97.2
+recent_releases_count: 70
+updated_issues_count: 5395
+closed_issues_count: 3062
+comment_frequency: 5.5
+dependents_count: 454393
+criticality_score: 0.99107
 ```
 
 You can add your own parameters to the criticality score calculation. For

--- a/criticality_score/run.py
+++ b/criticality_score/run.py
@@ -37,7 +37,7 @@ _CACHED_GITHUB_TOKEN = None
 _CACHED_GITHUB_TOKEN_OBJ = None
 
 PARAMS = [
-    'created_since', 'updated_since', 'contributor_count', 'org_count',
+    'description', 'created_since', 'updated_since', 'contributor_count', 'watchers_count', 'org_count',
     'commit_frequency', 'recent_releases_count', 'updated_issues_count',
     'closed_issues_count', 'comment_frequency', 'dependents_count'
 ]
@@ -63,6 +63,10 @@ class Repository:
         raise NotImplementedError
 
     @property
+    def description(self):
+        raise NotImplementedError
+
+    @property
     def last_commit(self):
         raise NotImplementedError
 
@@ -76,6 +80,10 @@ class Repository:
 
     @property
     def contributor_count(self):
+        raise NotImplementedError
+
+    @property
+    def watchers_count(self):
         raise NotImplementedError
 
     @property
@@ -143,6 +151,10 @@ class GitHubRepository(Repository):
     @property
     def language(self):
         return self._repo.language
+
+    @property
+    def description(self):
+        return self._repo.description
 
     @property
     def last_commit(self):
@@ -218,6 +230,10 @@ class GitHubRepository(Repository):
         except Exception:
             # Very large number of contributors, i.e. 5000+. Cap at 5,000.
             return 5000
+
+    @property
+    def watchers_count(self):
+        return self._repo.watchers_count
 
     @property
     def org_count(self):


### PR DESCRIPTION
I wanted to submit a suggestion to include GitHub Watchers (to help assess popularity) and the GitHub Description (to clarify the project's overall goal). I am currently helping contribute to OSSF's Security Metrics project, in which we are retrieving several of the GitHub metrics covered in this project (but also need to analyze the two mentioned above to help with our overall security assessment). If these can be included via the pull request I have submitted that would be extremely helpful. Thank you!