### PR TITLE
Remove "Finished()" API in favor of the io.EOF error.

### DIFF
--- a/cmd/enumerate_github/githubsearch/repos.go
+++ b/cmd/enumerate_github/githubsearch/repos.go
@@ -1,7 +1,9 @@
 package githubsearch
 
 import (
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/ossf/criticality_score/cmd/enumerate_github/pagination"
 	"github.com/shurcooL/githubv4"
@@ -110,9 +112,11 @@ func (re *Searcher) ReposByStars(baseQuery string, minStars int, overlap int, em
 		total := c.Total()
 		seen := 0
 		stars = 0
-		for !c.Finished() {
+		for {
 			obj, err := c.Next()
-			if err != nil {
+			if obj == nil && errors.Is(err, io.EOF) {
+				break
+			} else if err != nil {
 				return err
 			}
 			repo := obj.(repo)

--- a/cmd/enumerate_github/pagination/pagination.go
+++ b/cmd/enumerate_github/pagination/pagination.go
@@ -58,25 +58,24 @@ func (c *Cursor) isLastPage() bool {
 	return !c.query.HasNextPage()
 }
 
-func (c *Cursor) Finished() bool {
-	return c.atEndOfPage() && c.isLastPage()
-}
-
 func (c *Cursor) Total() int {
 	return c.query.Total()
 }
 
 func (c *Cursor) Next() (interface{}, error) {
-	if c.Finished() {
-		// We've finished so return an EOF
-		return nil, io.EOF
-	} else if c.atEndOfPage() {
-		// We're at the end of the page, but not finished, so grab the next page.
+	if c.atEndOfPage() {
+		// There are no more nodes in this page, so we need another page.
+		if c.isLastPage() {
+			// There are no more pages, so return an EOF
+			return nil, io.EOF
+		}
+		// Grab the next page.
 		if err := c.queryNextPage(); err != nil {
 			return nil, err
 		}
-		// Make sure we didn't get an empty result.
 		if c.atEndOfPage() {
+			// Despite grabing a new page we have no results,
+			// so return an EOF.
 			return nil, io.EOF
 		}
 	}


### PR DESCRIPTION
This better handles the case where another page is left, but
contains no nodes and makes it less ambiguous.