### PR TITLE
Add a library to handle the retry logic.

### DIFF
--- a/internal/retry/request.go
+++ b/internal/retry/request.go
@@ -146,8 +146,25 @@ func NewRequest(r *http.Request, client func(*http.Request) (*http.Response, err
 	}
 }
 
+// Done indicates whether or not the request can be attempted any more times.
+//
+// Initially Done will be false. It will move to true when the following
+// occurs:
+//
+//  1. Do returns a 2xx or 3xx response
+//  2. Do returns an error
+//  3. The number of attempts exceeds MaxRetries
+//  4. No RetryStrategy was returned or only NoRetry, and RetryAfter() had no
+//  delay.
+//
+// If Done returns true, Do must never be called again, otherwise Do will
+// return ErrorNoMoreAttempts.
+//
+// If Done returns false, Do needs to be called.
+//
+// If Do has never been called, this method will always return false.
 func (r *Request) Done() bool {
-	return r.done || r.attempts >= r.o.maxRetries
+	return r.done || r.attempts > r.o.maxRetries
 }
 
 func (r *Request) onError(err error) (*http.Response, error) {

--- a/internal/retry/request.go
+++ b/internal/retry/request.go
@@ -1,0 +1,248 @@
+package retry
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultMaxRetries      = 5
+	DefaultInitialDuration = 2 * time.Minute
+)
+
+var (
+	ErrorNoMoreAttempts = errors.New("request cannot by retried")
+)
+
+type RetryStrategy int
+
+const (
+	NoRetry RetryStrategy = iota
+	RetryImmediate
+	RetryWithInitialDelay
+)
+
+// String implements the Stringer interface.
+func (s RetryStrategy) String() string {
+	switch s {
+	case NoRetry:
+		return "NoRetry"
+	case RetryImmediate:
+		return "RetryImmediate"
+	case RetryWithInitialDelay:
+		return "RetryWithInitialDelay"
+	default:
+		panic("Invalid RetryStrategy")
+	}
+}
+
+// A RetryStrategyFn is used to determine whether or not a retry is needed, and
+// if so, whether an initial delay is needed or not.
+type RetryStrategyFn func(*http.Response) (RetryStrategy, error)
+
+// A RetryAfterFn is used to parse the delay from the Retry-After header.
+//
+// The returned time.Duration will be used as the delay.
+//
+// If the header is not set, or the value cannot be parsed, a Duration of 0
+// must be returned.
+type RetryAfterFn func(*http.Response) time.Duration
+
+// A BackoffFn takes the previous delay and calculates a new, longer delay.
+//
+// This is used to extend the time between retries.
+type BackoffFn func(time.Duration) time.Duration
+
+// SleepFn must cause the current goroutine to sleep for the allocated Duration.
+//
+// The usual implementation of this is time.Sleep. This is provided for testing.
+type sleepFn func(time.Duration)
+
+// DefaultBackoff will double the duration d if it is greater than zero,
+// otherwise it returns 1 minute.
+func DefaultBackoff(d time.Duration) time.Duration {
+	if d <= 0 {
+		return time.Minute
+	} else {
+		return d * 2
+	}
+}
+
+type Options struct {
+	maxRetries         int
+	initialDelay       time.Duration
+	backoff            BackoffFn
+	sleep              sleepFn
+	retryAfter         RetryAfterFn
+	retryStrategyFuncs []RetryStrategyFn
+}
+type Option interface {
+	Apply(*Options)
+}
+type optionFn func(*Options)
+
+func (o optionFn) Apply(opts *Options) {
+	o(opts)
+}
+
+func MaxRetries(max int) Option {
+	return optionFn(func(o *Options) {
+		o.maxRetries = max
+	})
+}
+
+func Backoff(bo BackoffFn) Option {
+	return optionFn(func(o *Options) {
+		o.backoff = bo
+	})
+}
+
+func InitialDelay(d time.Duration) Option {
+	return optionFn(func(o *Options) {
+		o.initialDelay = d
+	})
+}
+
+func RetryAfter(ra RetryAfterFn) Option {
+	return optionFn(func(o *Options) {
+		o.retryAfter = ra
+	})
+}
+
+func Strategy(rs RetryStrategyFn) Option {
+	return optionFn(func(o *Options) {
+		o.retryStrategyFuncs = append(o.retryStrategyFuncs, rs)
+	})
+}
+
+func MakeOptions(os ...Option) *Options {
+	opts := &Options{
+		maxRetries:   DefaultMaxRetries,
+		initialDelay: DefaultInitialDuration,
+		sleep:        time.Sleep,
+		backoff:      DefaultBackoff,
+	}
+	for _, o := range os {
+		o.Apply(opts)
+	}
+	return opts
+}
+
+type Request struct {
+	client   func(*http.Request) (*http.Response, error)
+	r        *http.Request
+	o        *Options
+	attempts int
+	done     bool
+	delay    time.Duration
+}
+
+func NewRequest(r *http.Request, client func(*http.Request) (*http.Response, error), o *Options) *Request {
+	return &Request{
+		client: client,
+		r:      r,
+		o:      o,
+	}
+}
+
+func (r *Request) Done() bool {
+	return r.done || r.attempts >= r.o.maxRetries
+}
+
+func (r *Request) onError(err error) (*http.Response, error) {
+	r.done = true
+	return nil, err
+}
+
+func (r *Request) onDone(resp *http.Response, err error) (*http.Response, error) {
+	r.done = true
+	return resp, err
+}
+
+func (r *Request) Do() (*http.Response, error) {
+	if r.Done() {
+		// Already done, so don't attempt any more.
+		return nil, ErrorNoMoreAttempts
+	}
+	if r.attempts > 0 {
+		// This is a retry!
+		if r.delay > 0 {
+			// Wait if we have a delay
+			r.o.sleep(r.delay)
+		}
+		// Update the delay
+		r.delay = r.o.backoff(r.delay)
+	}
+	// Bump the number of attempts
+	r.attempts++
+
+	// Issue the request
+	resp, err := r.client(r.r)
+	if err != nil {
+		// Return the response and the error if the client returned an error
+		// TODO: pass err to the strategy funcs.
+		return r.onDone(resp, err)
+	}
+
+	// Immediate success if the request is 2xx or 3xx
+	if http.StatusOK <= resp.StatusCode && resp.StatusCode < http.StatusBadRequest {
+		return r.onDone(resp, err)
+	}
+
+	if r.o.retryAfter != nil {
+		// Check if the Retry-After header is set
+		d := r.o.retryAfter(resp)
+		if d != 0 {
+			// We have the Retry-After header so set the delay and return
+			r.delay = d
+			return resp, err
+		}
+	}
+
+	// Check each of the retryStrategyFuncs to see if we should retry
+	s := NoRetry
+	var errS error
+	for _, fn := range r.o.retryStrategyFuncs {
+		s, errS = fn(resp)
+		if errS != nil {
+			return r.onError(errS)
+		}
+		if s != NoRetry {
+			// We found a strategy that required a retry
+			// TODO: we may want to find the retry needing the longest delay
+			break
+		}
+	}
+	if s == NoRetry {
+		return r.onDone(resp, err)
+	}
+	// Only apply the strategy on the first iteration
+	if r.attempts == 1 && s == RetryWithInitialDelay {
+		r.delay = r.o.initialDelay
+	}
+
+	return resp, err
+}
+
+func NewRoundTripper(inner http.RoundTripper, o ...Option) http.RoundTripper {
+	return &roundTripper{
+		inner: inner,
+		o:     MakeOptions(o...),
+	}
+}
+
+type roundTripper struct {
+	inner http.RoundTripper
+	o     *Options
+}
+
+func (rt *roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	rr := NewRequest(r, rt.inner.RoundTrip, rt.o)
+	for !rr.Done() {
+		resp, err = rr.Do()
+	}
+	return resp, err
+}

--- a/internal/retry/request_test.go
+++ b/internal/retry/request_test.go
@@ -1,0 +1,155 @@
+package retry
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInit_NotDone(t *testing.T) {
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, MakeOptions())
+
+	if req.Done() {
+		t.Fatalf("Done() == true; want false")
+	}
+}
+
+func Test200NoRetryStrategyFunc(t *testing.T) {
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, MakeOptions())
+	resp, err := req.Do()
+
+	if !req.Done() {
+		t.Fatalf("Done() == false; want true")
+	}
+	if err != nil {
+		t.Fatalf("Do() returned err %v; want no err", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Do() return response with status == %d; want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestDoAfterDoneReturnsError(t *testing.T) {
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, MakeOptions())
+
+	// This Do() is successful
+	req.Do()
+
+	// This Do() returns an error.
+	resp, err := req.Do()
+	if err != ErrorNoMoreAttempts {
+		t.Fatalf("Do() returned err %v; want %v", err, ErrorNoMoreAttempts)
+	}
+	if resp != nil {
+		t.Fatalf("Do() returned a response; want nil")
+	}
+}
+
+func Test2xx3xxAlwaysDone(t *testing.T) {
+	for code := http.StatusOK; code < http.StatusBadRequest; code++ {
+		t.Run(fmt.Sprintf("status %d", code), func(t *testing.T) {
+			req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: code,
+					Body:       ioutil.NopCloser(strings.NewReader("")),
+				}, nil
+			}, MakeOptions(Strategy(func(_ *http.Response) (RetryStrategy, error) {
+				// Always force a retry if the strategy is called.
+				return RetryImmediate, nil
+			})))
+			req.Do()
+			if !req.Done() {
+				t.Fatalf("Done() == false; want true")
+			}
+		})
+	}
+}
+
+func TestRetryAfterZeroDuration(t *testing.T) {
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, MakeOptions(RetryAfter(func(_ *http.Response) time.Duration {
+		return 0
+	})))
+	req.Do()
+	if !req.Done() {
+		t.Fatalf("Done() == false; want true")
+	}
+}
+
+func TestRetryAfterDuration(t *testing.T) {
+	slept := time.Duration(0)
+	opts := MakeOptions(RetryAfter(func(_ *http.Response) time.Duration {
+		return time.Minute
+	}))
+	opts.sleep = func(d time.Duration) {
+		slept += d
+	}
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, opts)
+	req.Do()
+	if req.Done() {
+		t.Fatalf("Done() == true; want false")
+	}
+
+	req.Do()
+	if req.Done() {
+		t.Fatalf("Done() == true; want false")
+	}
+	if slept != time.Minute {
+		t.Fatalf("Only slept for %d; want sleep for %d", slept, time.Minute)
+	}
+}
+
+func TestZeroMaxRetries(t *testing.T) {
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, MakeOptions(MaxRetries(0)))
+	if !req.Done() {
+		t.Fatalf("Done() == false; want true")
+	}
+}
+
+func TestOneMaxRetriesOnlyTriesOnce(t *testing.T) {
+	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}, MakeOptions(MaxRetries(1), RetryAfter(func(_ *http.Response) time.Duration {
+		// Force a retry
+		return time.Minute
+	})))
+	req.Do()
+	if !req.Done() {
+		t.Fatalf("Done() == false; want true")
+	}
+}

--- a/internal/retry/request_test.go
+++ b/internal/retry/request_test.go
@@ -126,25 +126,13 @@ func TestRetryAfterDuration(t *testing.T) {
 	}
 }
 
-func TestZeroMaxRetries(t *testing.T) {
-	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader("")),
-		}, nil
-	}, MakeOptions(MaxRetries(0)))
-	if !req.Done() {
-		t.Fatalf("Done() == false; want true")
-	}
-}
-
-func TestOneMaxRetriesOnlyTriesOnce(t *testing.T) {
+func TestZeroMaxRetriesOnlyTriesOnce(t *testing.T) {
 	req := NewRequest(&http.Request{}, func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusBadRequest,
 			Body:       ioutil.NopCloser(strings.NewReader("")),
 		}, nil
-	}, MakeOptions(MaxRetries(1), RetryAfter(func(_ *http.Response) time.Duration {
+	}, MakeOptions(MaxRetries(0), RetryAfter(func(_ *http.Response) time.Duration {
 		// Force a retry
 		return time.Minute
 	})))


### PR DESCRIPTION
A following PR will use this library to handle retries for the GitHub API.

This library is written this way to facilitate testing, which I thought
was particularly important for retry related logic as it is hard to
cover all the various cases during manual testing.