### PR TITLE
Add retry logic for github errors to improve reliability.

### DIFF
--- a/cmd/collect_signals/main.go
+++ b/cmd/collect_signals/main.go
@@ -149,7 +149,7 @@ func main() {
 	http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost = *workersFlag * 5
 
 	// Prepare a client for communicating with GitHub's GraphQLv4 API and Restv3 API
-	rt := roundtripper.NewTransport(ctx, scLogger)
+	rt := githubapi.NewRoundTripper(roundtripper.NewTransport(ctx, scLogger), logger)
 	httpClient := &http.Client{
 		Transport: rt,
 	}

--- a/internal/githubapi/roundtripper.go
+++ b/internal/githubapi/roundtripper.go
@@ -100,11 +100,11 @@ func (s *strategies) SecondaryRateLimit(r *http.Response) (retry.RetryStrategy, 
 			}).Warn("ReadAll failed.")
 		return retry.NoRetry, err
 	}
-	// Don't error check the unmarshall - if it is an error and the parsing has
-	// failed then will return with no retry. A parsing error here would mean
-	// the server did something wrong. Not attempting a retry will cause the
-	// response to be processed again by go-github with an error being
-	// generated there.
+	// Don't error check the unmarshall - if there is an error and the parsing
+	// has failed then this function will return with no retry. A parsing error
+	// here would mean the server did something wrong. Not attempting a retry
+	// will cause the response to be processed again by go-github with an error
+	// being generated there.
 	json.Unmarshal(data, errorResponse)
 	s.logger.WithFields(log.Fields{
 		"url":     errorResponse.DocumentationURL,

--- a/internal/githubapi/roundtripper.go
+++ b/internal/githubapi/roundtripper.go
@@ -1,0 +1,129 @@
+package githubapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v44/github"
+	"github.com/ossf/criticality_score/internal/retry"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	githubErrorIdSearch = "\"error_500\""
+)
+
+var (
+	issueCommentsRe = regexp.MustCompile("^repos/[^/]+/[^/]+/issues/comments$")
+)
+
+func NewRoundTripper(rt http.RoundTripper, logger *log.Logger) http.RoundTripper {
+	s := &strategies{logger: logger}
+	return retry.NewRoundTripper(rt,
+		retry.InitialDelay(2*time.Minute),
+		retry.RetryAfter(s.RetryAfter),
+		retry.Strategy(s.SecondaryRateLimit),
+		retry.Strategy(s.ServerError400),
+		retry.Strategy(s.ServerError),
+	)
+}
+
+type strategies struct {
+	logger *log.Logger
+}
+
+func respBodyContains(r *http.Response, search string) (bool, error) {
+	data, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	if err != nil {
+		return false, err
+	}
+	return bytes.Contains(data, []byte(search)), nil
+}
+
+// ServerError implements retry.RetryStrategyFn
+func (s *strategies) ServerError(r *http.Response) (retry.RetryStrategy, error) {
+	if r.StatusCode < 500 || 600 <= r.StatusCode {
+		return retry.NoRetry, nil
+	}
+	s.logger.WithField("status", r.Status).Warn("5xx: detected")
+	if issueCommentsRe.MatchString(strings.Trim(r.Request.URL.Path, "/")) {
+		s.logger.Warn("Ignoring /repos/X/Y/issues/comments url.")
+		// If the req url was /repos/[owner]/[name]/issues/comments pass the
+		// error through as it is likely a GitHub bug.
+		return retry.NoRetry, nil
+	}
+	return retry.RetryImmediate, nil
+
+}
+
+// ServerError400 implements retry.RetryStrategyFn
+func (s *strategies) ServerError400(r *http.Response) (retry.RetryStrategy, error) {
+	if r.StatusCode != http.StatusBadRequest {
+		return retry.NoRetry, nil
+	}
+	s.logger.Warn("400: bad request detected")
+	if r.Header.Get("Content-Type") != "text/html" {
+		return retry.NoRetry, nil
+	}
+	s.logger.Debug("It's a text/html doc")
+	if isError, err := respBodyContains(r, githubErrorIdSearch); isError {
+		s.logger.Debug("Found target string - assuming 500.")
+		return retry.RetryImmediate, nil
+	} else {
+		return retry.NoRetry, err
+	}
+}
+
+// SecondaryRateLimit implements retry.RetryStrategyFn
+func (s *strategies) SecondaryRateLimit(r *http.Response) (retry.RetryStrategy, error) {
+	if r.StatusCode != http.StatusForbidden {
+		return retry.NoRetry, nil
+	}
+	s.logger.Warn("403: forbidden detected")
+	errorResponse := &github.ErrorResponse{Response: r}
+	data, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+	if err != nil || data == nil {
+		s.logger.WithFields(
+			log.Fields{
+				"error":    err,
+				"data_nil": (data == nil),
+			}).Warn("ReadAll failed.")
+		return retry.NoRetry, err
+	}
+	json.Unmarshal(data, errorResponse)
+	s.logger.WithFields(log.Fields{
+		"url":     errorResponse.DocumentationURL,
+		"message": errorResponse.Message,
+	}).Warn("Error response data")
+	if strings.HasSuffix(errorResponse.DocumentationURL, "#abuse-rate-limits") ||
+		strings.HasSuffix(errorResponse.DocumentationURL, "#secondary-rate-limits") {
+		s.logger.Warn("Secondary rate limit hit.")
+		return retry.RetryWithInitialDelay, nil
+	}
+	s.logger.Warn("Not an abuse rate limit error.")
+	return retry.NoRetry, nil
+}
+
+// RetryAfter implements retry.RetryAfterFn
+// TODO: move to retry once we're confident it is working.
+func (s *strategies) RetryAfter(r *http.Response) time.Duration {
+	if v := r.Header["Retry-After"]; len(v) > 0 {
+		s.logger.Warn("Detected Retry-After header.")
+		// According to GitHub support, the "Retry-After" header value will be
+		// an integer which represents the number of seconds that one should
+		// wait before resuming making requests.
+		retryAfterSeconds, _ := strconv.ParseInt(v[0], 10, 64) // Error handling is noop.
+		return time.Duration(retryAfterSeconds) * time.Second
+	}
+	return 0
+}

--- a/internal/githubapi/roundtripper.go
+++ b/internal/githubapi/roundtripper.go
@@ -100,6 +100,11 @@ func (s *strategies) SecondaryRateLimit(r *http.Response) (retry.RetryStrategy, 
 			}).Warn("ReadAll failed.")
 		return retry.NoRetry, err
 	}
+	// Don't error check the unmarshall - if it is an error and the parsing has
+	// failed then will return with no retry. A parsing error here would mean
+	// the server did something wrong. Not attempting a retry will cause the
+	// response to be processed again by go-github with an error being
+	// generated there.
 	json.Unmarshal(data, errorResponse)
 	s.logger.WithFields(log.Fields{
 		"url":     errorResponse.DocumentationURL,

--- a/internal/githubapi/roundtripper_test.go
+++ b/internal/githubapi/roundtripper_test.go
@@ -1,0 +1,323 @@
+package githubapi
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ossf/criticality_score/internal/retry"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	testAbuseRateLimitDocUrl     = "https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits"
+	testSecondaryRateLimitDocUrl = "https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits"
+)
+
+func newTestStrategies() *strategies {
+	logger := log.New()
+	logger.Out = ioutil.Discard
+	return &strategies{logger: logger}
+}
+
+type readerFn func(p []byte) (n int, err error)
+
+// Read implements the io.Reader interface
+func (r readerFn) Read(p []byte) (n int, err error) {
+	return r(p)
+}
+
+func TestRetryAfter(t *testing.T) {
+	r := &http.Response{Header: http.Header{http.CanonicalHeaderKey("Retry-After"): {"123"}}}
+	if d := newTestStrategies().RetryAfter(r); d != 123*time.Second {
+		t.Fatalf("RetryAfter() == %d, want %v", d, 123*time.Second)
+	}
+}
+
+func TestRetryAfter_NoHeader(t *testing.T) {
+	if d := newTestStrategies().RetryAfter(&http.Response{}); d != 0 {
+		t.Fatalf("RetryAfter() == %d, want 0", d)
+	}
+}
+
+func TestRetryAfter_InvalidTime(t *testing.T) {
+	r := &http.Response{Header: http.Header{http.CanonicalHeaderKey("Retry-After"): {"junk"}}}
+	if d := newTestStrategies().RetryAfter(r); d != 0 {
+		t.Fatalf("RetryAfter() == %d, want 0", d)
+	}
+}
+
+func TestRetryAfter_ZeroTime(t *testing.T) {
+	r := &http.Response{Header: http.Header{http.CanonicalHeaderKey("Retry-After"): {"0"}}}
+	if d := newTestStrategies().RetryAfter(r); d != 0 {
+		t.Fatalf("RetryAfter() == %d, want 0", d)
+	}
+}
+
+func TestServerError(t *testing.T) {
+	u, _ := url.Parse("https://api.github.com/repos/example/example")
+	r := &http.Response{
+		Request:    &http.Request{URL: u},
+		StatusCode: http.StatusInternalServerError,
+	}
+	s, err := newTestStrategies().ServerError(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.RetryImmediate {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.RetryImmediate)
+	}
+}
+
+func TestServerError_IssueComments(t *testing.T) {
+	u, _ := url.Parse("https://api.github.com/repos/example/example/issues/comments/")
+	r := &http.Response{
+		Request:    &http.Request{URL: u},
+		StatusCode: http.StatusInternalServerError,
+	}
+	s, err := newTestStrategies().ServerError(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.NoRetry {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.NoRetry)
+	}
+}
+
+func TestServerError_StatusCodes(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		strategy   retry.RetryStrategy
+	}{
+		{statusCode: http.StatusOK, strategy: retry.NoRetry},
+		{statusCode: http.StatusCreated, strategy: retry.NoRetry},
+		{statusCode: http.StatusPermanentRedirect, strategy: retry.NoRetry},
+		{statusCode: http.StatusFound, strategy: retry.NoRetry},
+		{statusCode: http.StatusBadRequest, strategy: retry.NoRetry},
+		{statusCode: http.StatusConflict, strategy: retry.NoRetry},
+		{statusCode: http.StatusFailedDependency, strategy: retry.NoRetry},
+		{statusCode: http.StatusGone, strategy: retry.NoRetry},
+		{statusCode: http.StatusInternalServerError, strategy: retry.RetryImmediate},
+		{statusCode: http.StatusNotImplemented, strategy: retry.RetryImmediate},
+		{statusCode: http.StatusBadGateway, strategy: retry.RetryImmediate},
+		{statusCode: http.StatusServiceUnavailable, strategy: retry.RetryImmediate},
+		{statusCode: http.StatusGatewayTimeout, strategy: retry.RetryImmediate},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("status %d", test.statusCode), func(t *testing.T) {
+			u, _ := url.Parse("https://api.github.com/repos/example/example")
+			r := &http.Response{
+				Request:    &http.Request{URL: u},
+				StatusCode: test.statusCode,
+			}
+			s, _ := newTestStrategies().ServerError(r)
+			if s != test.strategy {
+				t.Fatalf("ServerError() == %v, want %v", s, test.strategy)
+			}
+		})
+	}
+}
+
+func TestServerError400(t *testing.T) {
+	r := &http.Response{
+		Header:     http.Header{http.CanonicalHeaderKey("Content-Type"): {"text/html"}},
+		StatusCode: http.StatusBadRequest,
+		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`<html><body>This is <span id="error_500">an error</span></body></html>`))),
+	}
+	s, err := newTestStrategies().ServerError400(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.RetryImmediate {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.RetryImmediate)
+	}
+}
+
+func TestServerError400_NoMatchingString(t *testing.T) {
+	r := &http.Response{
+		Header:     http.Header{http.CanonicalHeaderKey("Content-Type"): {"text/html"}},
+		StatusCode: http.StatusBadRequest,
+		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`<html><body>Web Page</body></html`))),
+	}
+	s, err := newTestStrategies().ServerError400(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.NoRetry {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.NoRetry)
+	}
+}
+
+func TestServerError400_BodyError(t *testing.T) {
+	want := errors.New("test error")
+	r := &http.Response{
+		Header:     http.Header{http.CanonicalHeaderKey("Content-Type"): {"text/html"}},
+		StatusCode: http.StatusBadRequest,
+		Body: ioutil.NopCloser(readerFn(func(b []byte) (int, error) {
+			return 0, want
+		})),
+	}
+	_, err := newTestStrategies().ServerError400(r)
+	if err == nil {
+		t.Fatalf("ServerError() returned no error, want %v", want)
+	}
+	if err != want {
+		t.Fatalf("ServerError() errored %v, want %v", err, want)
+	}
+}
+
+func TestServerError400_NotHTML(t *testing.T) {
+	r := &http.Response{
+		Header:     http.Header{http.CanonicalHeaderKey("Content-Type"): {"text/plain"}},
+		StatusCode: http.StatusBadRequest,
+		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`text doc`))),
+	}
+	s, err := newTestStrategies().ServerError400(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.NoRetry {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.NoRetry)
+	}
+}
+
+func TestServerError400_StatusCodes(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		strategy   retry.RetryStrategy
+	}{
+		{statusCode: http.StatusOK, strategy: retry.NoRetry},
+		{statusCode: http.StatusCreated, strategy: retry.NoRetry},
+		{statusCode: http.StatusPermanentRedirect, strategy: retry.NoRetry},
+		{statusCode: http.StatusFound, strategy: retry.NoRetry},
+		{statusCode: http.StatusBadRequest, strategy: retry.RetryImmediate},
+		{statusCode: http.StatusConflict, strategy: retry.NoRetry},
+		{statusCode: http.StatusFailedDependency, strategy: retry.NoRetry},
+		{statusCode: http.StatusGone, strategy: retry.NoRetry},
+		{statusCode: http.StatusInternalServerError, strategy: retry.NoRetry},
+		{statusCode: http.StatusNotImplemented, strategy: retry.NoRetry},
+		{statusCode: http.StatusBadGateway, strategy: retry.NoRetry},
+		{statusCode: http.StatusServiceUnavailable, strategy: retry.NoRetry},
+		{statusCode: http.StatusGatewayTimeout, strategy: retry.NoRetry},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("status %d", test.statusCode), func(t *testing.T) {
+			r := &http.Response{
+				Header:     http.Header{http.CanonicalHeaderKey("Content-Type"): {"text/html"}},
+				StatusCode: test.statusCode,
+				Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`<html><body>This is <span id="error_500">an error</span></body></html>`))),
+			}
+			s, err := newTestStrategies().ServerError400(r)
+			if err != nil {
+				t.Fatalf("ServerError() errored %v, want no error", err)
+			}
+			if s != test.strategy {
+				t.Fatalf("ServerError() == %v, want %v", s, test.strategy)
+			}
+		})
+	}
+}
+
+func TestSecondaryRateLimit(t *testing.T) {
+	r := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body: ioutil.NopCloser(bytes.NewBuffer(
+			[]byte(fmt.Sprintf(`{"message": "test", "documentation_url": "%s"}`, testSecondaryRateLimitDocUrl)))),
+	}
+	s, err := newTestStrategies().SecondaryRateLimit(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.RetryWithInitialDelay {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.RetryWithInitialDelay)
+	}
+}
+
+func TestSecondaryRateLimit_AbuseUrl(t *testing.T) {
+	r := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body: ioutil.NopCloser(bytes.NewBuffer(
+			[]byte(fmt.Sprintf(`{"message": "test", "documentation_url": "%s"}`, testAbuseRateLimitDocUrl)))),
+	}
+	s, err := newTestStrategies().SecondaryRateLimit(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.RetryWithInitialDelay {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.RetryWithInitialDelay)
+	}
+}
+
+func TestSecondaryRateLimit_OtherUrl(t *testing.T) {
+	r := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"message": "test", "documentation_url": "https://example.org/"}`))),
+	}
+	s, err := newTestStrategies().SecondaryRateLimit(r)
+	if err != nil {
+		t.Fatalf("ServerError() errored %v, want no error", err)
+	}
+	if s != retry.NoRetry {
+		t.Fatalf("ServerError() == %v, want %v", s, retry.NoRetry)
+	}
+}
+
+func TestSecondaryRateLimit_BodyError(t *testing.T) {
+	want := errors.New("test error")
+	r := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Body: ioutil.NopCloser(readerFn(func(b []byte) (int, error) {
+			return 0, want
+		})),
+	}
+	_, err := newTestStrategies().SecondaryRateLimit(r)
+	if err == nil {
+		t.Fatalf("ServerError() returned no error, want %v", want)
+	}
+	if err != want {
+		t.Fatalf("ServerError() errored %v, want %v", err, want)
+	}
+}
+
+func TestSecondaryRateLimit_StatusCodes(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		strategy   retry.RetryStrategy
+	}{
+		{statusCode: http.StatusOK, strategy: retry.NoRetry},
+		{statusCode: http.StatusCreated, strategy: retry.NoRetry},
+		{statusCode: http.StatusPermanentRedirect, strategy: retry.NoRetry},
+		{statusCode: http.StatusFound, strategy: retry.NoRetry},
+		{statusCode: http.StatusBadRequest, strategy: retry.NoRetry},
+		{statusCode: http.StatusForbidden, strategy: retry.RetryWithInitialDelay},
+		{statusCode: http.StatusConflict, strategy: retry.NoRetry},
+		{statusCode: http.StatusFailedDependency, strategy: retry.NoRetry},
+		{statusCode: http.StatusGone, strategy: retry.NoRetry},
+		{statusCode: http.StatusInternalServerError, strategy: retry.NoRetry},
+		{statusCode: http.StatusNotImplemented, strategy: retry.NoRetry},
+		{statusCode: http.StatusBadGateway, strategy: retry.NoRetry},
+		{statusCode: http.StatusServiceUnavailable, strategy: retry.NoRetry},
+		{statusCode: http.StatusGatewayTimeout, strategy: retry.NoRetry},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("status %d", test.statusCode), func(t *testing.T) {
+			r := &http.Response{
+				StatusCode: test.statusCode,
+				Body: ioutil.NopCloser(bytes.NewBuffer(
+					[]byte(fmt.Sprintf(`{"message": "test", "documentation_url": "%s"}`, testSecondaryRateLimitDocUrl)))),
+			}
+			s, err := newTestStrategies().SecondaryRateLimit(r)
+			if err != nil {
+				t.Fatalf("ServerError() errored %v, want no error", err)
+			}
+			if s != test.strategy {
+				t.Fatalf("ServerError() == %v, want %v", s, test.strategy)
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. Adds a RetryAfter function for processing responses with `Retry-After` header (will move to the retry library in the future)
2. Adds a SecondaryRateLimit function for detecting rate limiting from GitHub and pausing immediately
3. Adds a ServerError400 function for detecting odd server errors from GitHub
4. Adds a ServerError function for detecting any 5xx server error and retrying (except for `issues/comments` which knowingly fails on lots for large numbers of comments).

All of these are well tested to ensure the retry behavior works correctly.