### PR TITLE
Add an initial k8s config for running the enumerate_github tool.

### DIFF
--- a/infra/k8s/enumerate_github.yaml
+++ b/infra/k8s/enumerate_github.yaml
@@ -1,0 +1,48 @@
+# Copyright 2022 Criticality Score Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: criticality-score-enumerate-github
+spec:
+  # Initially, run this daily at 23:00UTC for >=100 stars across 2021.
+  schedule: "0 23 * * *"
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: enumerate-github
+            image: gcr.io/openssf/criticality-score-enumerate-github:latest
+            args: ["gcs://ossf-criticality-score-url-data/[[runid]]/github.txt"]
+            imagePullPolicy: Always
+            env:
+            - name: GITHUB_AUTH_SERVER
+              value: "10.4.4.210:80"
+            - name: CRITICALITY_SCORE_OUTFILE_FORCE
+              value: "1"
+            - name: CRITICALITY_SCORE_STARS_MIN
+              value: "100"
+            - name: CRITICALITY_SCORE_START_DATE
+              value: "2021-01-01"
+            - name: CRITICALITY_SCORE_END_DATE
+              value: "2022-01-01"
+            resources:
+              limits:
+                memory: 1Gi
+              requests:
+                memory: 1Gi
+          restartPolicy: OnFailure


### PR DESCRIPTION
Currently, only runs for repos >= 100 stars, for 2021.

It is triggered each day at 23:00 UTC or 9am AEST.

Prior to running it needs the bucket to be created with access for the correct service account.