### PR TITLE
Add support for output enumerated urls in a scorecard compatible format.

### DIFF
--- a/cmd/enumerate_github/repowriter/scorecard.go
+++ b/cmd/enumerate_github/repowriter/scorecard.go
@@ -1,0 +1,33 @@
+package repowriter
+
+import (
+	"encoding/csv"
+	"io"
+)
+
+var header = []string{"repo", "metadata"}
+
+type scorecardWriter struct {
+	w *csv.Writer
+}
+
+// Scorecard creates a new Writer instance that is used to write a csv file
+// of repositories that is compatible with the github.com/ossf/scorecard
+// project.
+//
+// The csv file has a header row with columns "repo" and "metadata". Each
+// row consists of the repository url and blank metadata.
+func Scorecard(w io.Writer) Writer {
+	csvWriter := csv.NewWriter(w)
+	csvWriter.Write(header)
+	return &scorecardWriter{w: csvWriter}
+}
+
+// Write implements the Writer interface.
+func (w *scorecardWriter) Write(repo string) error {
+	if err := w.w.Write([]string{repo, ""}); err != nil {
+		return err
+	}
+	w.w.Flush()
+	return w.w.Error()
+}

--- a/cmd/enumerate_github/repowriter/scorecard_test.go
+++ b/cmd/enumerate_github/repowriter/scorecard_test.go
@@ -1,0 +1,24 @@
+package repowriter_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ossf/criticality_score/cmd/enumerate_github/repowriter"
+)
+
+func TestScorecardRepoWriter(t *testing.T) {
+	var buf bytes.Buffer
+	w := repowriter.Scorecard(&buf)
+	w.Write("https://github.com/example/example")
+	w.Write("https://github.com/ossf/criticality_score")
+
+	want := "repo,metadata\n" +
+		"https://github.com/example/example,\n" +
+		"https://github.com/ossf/criticality_score,\n"
+
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Fatalf("Scorecard() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/cmd/enumerate_github/repowriter/scorecard_test.go
+++ b/cmd/enumerate_github/repowriter/scorecard_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/ossf/criticality_score/cmd/enumerate_github/repowriter"
 )
 

--- a/cmd/enumerate_github/repowriter/text.go
+++ b/cmd/enumerate_github/repowriter/text.go
@@ -1,0 +1,22 @@
+package repowriter
+
+import (
+	"fmt"
+	"io"
+)
+
+type textWriter struct {
+	w io.Writer
+}
+
+// Text creates a new Writer instance that is used to write a simple text file
+// of repositories, where each line has a single repository url.
+func Text(w io.Writer) Writer {
+	return &textWriter{w}
+}
+
+// Write implements the Writer interface.
+func (w *textWriter) Write(repo string) error {
+	_, err := fmt.Fprintln(w.w, repo)
+	return err
+}

--- a/cmd/enumerate_github/repowriter/text_test.go
+++ b/cmd/enumerate_github/repowriter/text_test.go
@@ -1,0 +1,23 @@
+package repowriter_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/ossf/criticality_score/cmd/enumerate_github/repowriter"
+)
+
+func TestTextRepoWriter(t *testing.T) {
+	var buf bytes.Buffer
+	w := repowriter.Text(&buf)
+	w.Write("https://github.com/example/example")
+	w.Write("https://github.com/ossf/criticality_score")
+
+	want := "https://github.com/example/example\n" +
+		"https://github.com/ossf/criticality_score\n"
+
+	if diff := cmp.Diff(want, buf.String()); diff != "" {
+		t.Fatalf("Text() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/cmd/enumerate_github/repowriter/text_test.go
+++ b/cmd/enumerate_github/repowriter/text_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/ossf/criticality_score/cmd/enumerate_github/repowriter"
 )
 

--- a/cmd/enumerate_github/repowriter/type.go
+++ b/cmd/enumerate_github/repowriter/type.go
@@ -1,0 +1,66 @@
+package repowriter
+
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+type WriterType int
+
+const (
+	// WriterTypeText corresponds to the Writer returned by Text.
+	WriterTypeText = WriterType(iota)
+
+	// WriterTypeScorecard corresponds to the Writer returned by Scorecard.
+	WriterTypeScorecard
+)
+
+var ErrorUnknownRepoWriterType = errors.New("unknown repo writer type")
+
+// String implements the fmt.Stringer interface.
+func (t WriterType) String() string {
+	text, err := t.MarshalText()
+	if err != nil {
+		return ""
+	}
+	return string(text)
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (t WriterType) MarshalText() ([]byte, error) {
+	switch t {
+	case WriterTypeText:
+		return []byte("text"), nil
+	case WriterTypeScorecard:
+		return []byte("scorecard"), nil
+	default:
+		return []byte{}, ErrorUnknownRepoWriterType
+	}
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (t *WriterType) UnmarshalText(text []byte) error {
+	switch {
+	case bytes.Equal(text, []byte("text")):
+		*t = WriterTypeText
+	case bytes.Equal(text, []byte("scorecard")):
+		*t = WriterTypeScorecard
+	default:
+		return ErrorUnknownRepoWriterType
+	}
+	return nil
+}
+
+// New will return a new instance of the corresponding implementation of
+// Writer for the given WriterType.
+func (t *WriterType) New(w io.Writer) Writer {
+	switch *t {
+	case WriterTypeText:
+		return Text(w)
+	case WriterTypeScorecard:
+		return Scorecard(w)
+	default:
+		return nil
+	}
+}

--- a/cmd/enumerate_github/repowriter/type_test.go
+++ b/cmd/enumerate_github/repowriter/type_test.go
@@ -1,0 +1,87 @@
+package repowriter_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ossf/criticality_score/cmd/enumerate_github/repowriter"
+)
+
+func TestTypeString(t *testing.T) {
+	tests := []struct {
+		name       string
+		writerType repowriter.WriterType
+		want       string
+	}{
+		{name: "text", writerType: repowriter.WriterTypeText, want: "text"},
+		{name: "scorecard", writerType: repowriter.WriterTypeScorecard, want: "scorecard"},
+		{name: "unknown", writerType: repowriter.WriterType(10), want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.writerType.String()
+			if got != test.want {
+				t.Fatalf("String() == %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTypeMarshalText(t *testing.T) {
+	tests := []struct {
+		name       string
+		writerType repowriter.WriterType
+		want       string
+		err        error
+	}{
+		{name: "text", writerType: repowriter.WriterTypeText, want: "text"},
+		{name: "scorecard", writerType: repowriter.WriterTypeScorecard, want: "scorecard"},
+		{name: "unknown", writerType: repowriter.WriterType(10), want: "", err: repowriter.ErrorUnknownRepoWriterType},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.writerType.MarshalText()
+			if err != nil && !errors.Is(err, test.err) {
+				t.Fatalf("MarhsalText() == %v, want %v", err, test.err)
+			}
+			if err == nil {
+				if test.err != nil {
+					t.Fatalf("MarshalText() return nil error, want %v", test.err)
+				}
+				if string(got) != test.want {
+					t.Fatalf("MarhsalText() == %s, want %s", got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestTypeUnmarshalText(t *testing.T) {
+	tests := []struct {
+		input string
+		want  repowriter.WriterType
+		err   error
+	}{
+		{input: "text", want: repowriter.WriterTypeText},
+		{input: "scorecard", want: repowriter.WriterTypeScorecard},
+		{input: "", want: 0, err: repowriter.ErrorUnknownRepoWriterType},
+		{input: "unknown", want: 0, err: repowriter.ErrorUnknownRepoWriterType},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			var got repowriter.WriterType
+			err := got.UnmarshalText([]byte(test.input))
+			if err != nil && !errors.Is(err, test.err) {
+				t.Fatalf("UnmarshalText() == %v, want %v", err, test.err)
+			}
+			if err == nil {
+				if test.err != nil {
+					t.Fatalf("MarshalText() return nil error, want %v", test.err)
+				}
+				if got != test.want {
+					t.Fatalf("UnmarshalText() parsed %d, want %d", int(got), int(test.want))
+				}
+			}
+		})
+	}
+}

--- a/cmd/enumerate_github/repowriter/type_test.go
+++ b/cmd/enumerate_github/repowriter/type_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestTypeString(t *testing.T) {
+	//nolint:govet
 	tests := []struct {
 		name       string
 		writerType repowriter.WriterType
@@ -28,6 +29,7 @@ func TestTypeString(t *testing.T) {
 }
 
 func TestTypeMarshalText(t *testing.T) {
+	//nolint:govet
 	tests := []struct {
 		name       string
 		writerType repowriter.WriterType
@@ -57,6 +59,7 @@ func TestTypeMarshalText(t *testing.T) {
 }
 
 func TestTypeUnmarshalText(t *testing.T) {
+	//nolint:govet
 	tests := []struct {
 		input string
 		want  repowriter.WriterType

--- a/cmd/enumerate_github/repowriter/writer.go
+++ b/cmd/enumerate_github/repowriter/writer.go
@@ -1,0 +1,8 @@
+package repowriter
+
+// Writer is a simple interface for writing a repo. This interface is to
+// abstract output formats for lists of repository urls.
+type Writer interface {
+	// Write outputs a single repository url.
+	Write(repo string) error
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.18
 require (
 	cloud.google.com/go/bigquery v1.32.0
 	github.com/blendle/zapdriver v1.3.1
+	github.com/go-logr/zapr v1.2.3
+	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v44 v44.1.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/ossf/scorecard/v4 v4.1.1-0.20220413163106-b00b31646ab4
@@ -42,21 +44,17 @@ require (
 	github.com/bombsimon/logrusr/v2 v2.0.1 // indirect
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
-	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.4.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-github/v41 v41.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
-	github.com/googleapis/go-type-adapters v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
-	github.com/stretchr/testify v1.8.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,7 +28,6 @@ cloud.google.com/go v0.94.1/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW
 cloud.google.com/go v0.97.0/go.mod h1:GF7l59pYBVlXQIBLx3a761cZ41F9bBH3JUlihCt2Udc=
 cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2ZA=
 cloud.google.com/go v0.100.1/go.mod h1:fs4QogzfH5n2pBXBP9vRiU+eCny7lD2vmFZy79Iuw1U=
-cloud.google.com/go v0.100.2 h1:t9Iw5QH5v4XtlEQaCtUY7x6sCABps8sW0acw7e2WQ6Y=
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
 cloud.google.com/go v0.102.1 h1:vpK6iQWv/2uUeFJth4/cBHsQAGjn1iIE6AAlxipRaA0=
@@ -46,7 +45,6 @@ cloud.google.com/go/compute v1.2.0/go.mod h1:xlogom/6gr8RJGBe7nT2eGsQYAFUbbv8dbC
 cloud.google.com/go/compute v1.3.0/go.mod h1:cCZiE1NHEtai4wiufUhW8I8S1JKkAnhnQJWM7YD99wM=
 cloud.google.com/go/compute v1.5.0/go.mod h1:9SMHyhJlzhlkJqrPAc839t2BZFTSk6Jdj6mkzQJeu0M=
 cloud.google.com/go/compute v1.6.0/go.mod h1:T29tfhtVbq1wvAPo0E3+7vhgmkOYeXjhFvz/FMzPu0s=
-cloud.google.com/go/compute v1.6.1 h1:2sMmt8prCn7DPaG4Pmh0N3Inmc8cT8ae5k1M6VJ9Wqc=
 cloud.google.com/go/compute v1.6.1/go.mod h1:g85FgpzFvNULZ+S8AYq87axRKuf2Kh7deLqV/jJ3thU=
 cloud.google.com/go/compute v1.7.0 h1:v/k9Eueb8aAJ0vZuxKMrgm6kPhCLZU9HxFU+AFDs9Uk=
 cloud.google.com/go/compute v1.7.0/go.mod h1:435lt8av5oL9P3fv1OEzSbSUe+ybHXGMPQHHZWZxy9U=
@@ -75,7 +73,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.21.0/go.mod h1:XmRlxkgPjlBONznT2dDUU/5XlpU2OjMnKuqnZI01LAA=
-cloud.google.com/go/storage v1.22.0 h1:NUV0NNp9nkBuW66BFRLuMgldN60C57ET3dhbwLIYio8=
 cloud.google.com/go/storage v1.22.0/go.mod h1:GbaLEoMqbVm6sx3Z0R++gSiBlgMv6yUi2q1DeGFKQgE=
 cloud.google.com/go/storage v1.22.1/go.mod h1:S8N1cAStu7BOeFfE8KAQzmyyLkK8p/vmRq6kuBTW58Y=
 cloud.google.com/go/storage v1.25.0 h1:D2Dn0PslpK7Z3B2AvuUHyIC762bDbGJdlmQlCBR71os=
@@ -165,6 +162,7 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 h1:cJGRyzCSVwZC7zZZ1xbx9m32UnrK
 github.com/aws/aws-sdk-go-v2/service/sts v1.16.3/go.mod h1:bfBj0iVmsUyUg4weDB4NxktD9rDGeKSVWnjTnwbx9b8=
 github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
 github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
@@ -350,11 +348,9 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
-github.com/googleapis/gax-go/v2 v2.3.0 h1:nRJtk3y8Fm770D42QV6T90ZnvFZyk7agSo3Q+Z9p3WI=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR82awk=
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
-github.com/googleapis/go-type-adapters v1.0.0 h1:9XdMn+d/G57qq1s8dNc5IesGCXHf6V2HZ2JwRxfA2tA=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -451,6 +447,7 @@ github.com/ossf/scorecard/v4 v4.1.1-0.20220413163106-b00b31646ab4 h1:Db6m7J/xaIt
 github.com/ossf/scorecard/v4 v4.1.1-0.20220413163106-b00b31646ab4/go.mod h1:PbooSR+65A6HA+eoJ7ICwek/muANHZsR08QV24tuiKA=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -475,16 +472,13 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
-github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
-github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -511,6 +505,7 @@ go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
+go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -652,7 +647,6 @@ golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
-golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 h1:OSnWWcOd/CtWQC2cYSBgbTSJv3ciqd8r54ySIW2y3RE=
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2 h1:+jnHzr9VPj32ykQVai5DNahi9+NSp7yYuCsl5eAQtL0=
@@ -830,7 +824,6 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df h1:5Pf6pFKu98ODmgnpvkJ3kFUOQGGLIzLIkbzUHp47618=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f h1:uF6paiQQebLeSXkrTqHqz0MXhXXS1KgF41eUdBNvxK0=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
@@ -876,7 +869,6 @@ google.golang.org/api v0.69.0/go.mod h1:boanBiw+h5c3s+tBPgEzLDRHfFLWV0qXxRHz3ws7
 google.golang.org/api v0.70.0/go.mod h1:Bs4ZM2HGifEvXwd50TtW70ovgJffJYw2oRCOFU/SkfA=
 google.golang.org/api v0.71.0/go.mod h1:4PyU6e6JogV1f9eA4voyrTY2batOLdgZ5qZ5HOCc4j8=
 google.golang.org/api v0.74.0/go.mod h1:ZpfMZOVRMywNyvJFeqL9HRWBgAuRfSjJFpe9QtRRyDs=
-google.golang.org/api v0.75.0 h1:0AYh/ae6l9TDUvIQrDw5QRpM100P6oHgD+o3dYHMzJg=
 google.golang.org/api v0.75.0/go.mod h1:pU9QmyHLnzlpar1Mjt4IbapUCy8J+6HD6GeELN69ljA=
 google.golang.org/api v0.78.0/go.mod h1:1Sg78yoMLOhlQTeF+ARBoytAcH1NNyyl390YMy6rKmw=
 google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3Hyg=
@@ -982,8 +974,6 @@ google.golang.org/genproto v0.0.0-20220421151946-72621c1f0bd3/go.mod h1:8w6bsBMX
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
-google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd h1:e0TwkXOdbnH/1x5rc5MZ/VYyiZ4v+RdVfrGMqEwT68I=
-google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
@@ -1020,7 +1010,6 @@ google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.46.2 h1:u+MLGgVf7vRdjEYZ8wDFhAVNmhkbJ5hmrA1LMWK1CAQ=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.48.0 h1:rQOsyJ/8+ufEDJd/Gdsz7HG220Mh9HAhFHRGnIjda0w=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,3 +1,4 @@
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
@@ -11,8 +12,6 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
-go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=


### PR DESCRIPTION
To simplify productionizing, add support for returning enumerated repository urls in Scorecard's csv format.

This doesn't directly import `RepoFormat` from scorecard because:
- it is in an "internal" directory
- uses the unmaintained csvutil project to generate the header row

Signed-off-by: Caleb Brown <calebbrown@google.com>