### PR TITLE
Migrate the collect_signals tool over to zap for logging.

### DIFF
--- a/cmd/collect_signals/depsdev/collector.go
+++ b/cmd/collect_signals/depsdev/collector.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/bigquery"
-	log "github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 
 	"github.com/ossf/criticality_score/cmd/collect_signals/collector"
 	"github.com/ossf/criticality_score/cmd/collect_signals/projectrepo"
@@ -41,7 +41,7 @@ func (s *depsDevSet) Namespace() signal.Namespace {
 }
 
 type depsDevCollector struct {
-	logger     *log.Logger
+	logger     *zap.Logger
 	dependents *dependents
 }
 
@@ -60,7 +60,7 @@ func (c *depsDevCollector) Collect(ctx context.Context, r projectrepo.Repo) (sig
 	if t == "" {
 		return &s, nil
 	}
-	c.logger.WithField("url", r.URL().String()).Debug("Fetching deps.dev dependent count")
+	c.logger.With(zap.String("url", r.URL().String())).Debug("Fetching deps.dev dependent count")
 	deps, found, err := c.dependents.Count(ctx, n, t)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (c *depsDevCollector) Collect(ctx context.Context, r projectrepo.Repo) (sig
 // TODO add options to configure the dataset:
 //   - force dataset re-creation (-update-strategy = always,stale,weekly,monthly,never)
 //   - force dataset destruction (-depsdev-destroy-data)
-func NewCollector(ctx context.Context, logger *log.Logger, projectID, datasetName string) (collector.Collector, error) {
+func NewCollector(ctx context.Context, logger *zap.Logger, projectID, datasetName string) (collector.Collector, error) {
 	if projectID == "" {
 		projectID = bigquery.DetectProjectID
 	}

--- a/cmd/collect_signals/depsdev/dependents.go
+++ b/cmd/collect_signals/depsdev/dependents.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
-	log "github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 	_ "google.golang.org/api/bigquery/v2"
 )
 
@@ -66,14 +66,14 @@ FROM ` + "`{{.ProjectID}}.{{.DatasetName}}.{{.TableName}}`" + `
 WHERE ProjectName = @projectname AND ProjectType = @projecttype;
 `
 
-func NewDependents(ctx context.Context, client *bigquery.Client, logger *log.Logger, datasetName string) (*dependents, error) {
+func NewDependents(ctx context.Context, client *bigquery.Client, logger *zap.Logger, datasetName string) (*dependents, error) {
 	b := &bq{client: client}
 	c := &dependents{
 		b: b,
-		logger: logger.WithFields(log.Fields{
-			"project_id": b.Project(),
-			"dataset":    datasetName,
-		}),
+		logger: logger.With(
+			zap.String("project_id", b.Project()),
+			zap.String("dataset", datasetName),
+		),
 		datasetName: datasetName,
 	}
 	var err error
@@ -113,7 +113,7 @@ func NewDependents(ctx context.Context, client *bigquery.Client, logger *log.Log
 
 type dependents struct {
 	b            bqAPI
-	logger       *log.Entry
+	logger       *zap.Logger
 	snapshotTime time.Time
 	countQuery   string
 	datasetName  string

--- a/cmd/collect_signals/github/factory.go
+++ b/cmd/collect_signals/github/factory.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"net/url"
 
-	log "github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 
 	"github.com/ossf/criticality_score/cmd/collect_signals/projectrepo"
 	"github.com/ossf/criticality_score/internal/githubapi"
@@ -26,10 +26,10 @@ import (
 
 type factory struct {
 	client *githubapi.Client
-	logger *log.Logger
+	logger *zap.Logger
 }
 
-func NewRepoFactory(client *githubapi.Client, logger *log.Logger) projectrepo.Factory {
+func NewRepoFactory(client *githubapi.Client, logger *zap.Logger) projectrepo.Factory {
 	return &factory{
 		client: client,
 		logger: logger,
@@ -40,7 +40,7 @@ func (f *factory) New(ctx context.Context, u *url.URL) (projectrepo.Repo, error)
 	p := &repo{
 		client:  f.client,
 		origURL: u,
-		logger:  f.logger.WithField("url", u),
+		logger:  f.logger.With(zap.String("url", u.String())),
 	}
 	if err := p.init(ctx); err != nil {
 		return nil, err

--- a/cmd/collect_signals/github/repo.go
+++ b/cmd/collect_signals/github/repo.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"go.uber.org/zap"
 
 	"github.com/ossf/criticality_score/cmd/collect_signals/github/legacy"
 	"github.com/ossf/criticality_score/internal/githubapi"
@@ -29,7 +29,7 @@ import (
 type repo struct {
 	client  *githubapi.Client
 	origURL *url.URL
-	logger  *log.Entry
+	logger  *zap.Logger
 
 	BasicData *basicRepoData
 	realURL   *url.URL

--- a/internal/githubapi/roundtripper_test.go
+++ b/internal/githubapi/roundtripper_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ossf/criticality_score/internal/retry"
 	"go.uber.org/zap/zaptest"
+
+	"github.com/ossf/criticality_score/internal/retry"
 )
 
 const (


### PR DESCRIPTION
Zap is much better at production logging. This change helps prepare signal collection for productionization.