### PR TITLE
Make the output file an explicit flag, rather than a positional arg

### DIFF
--- a/cmd/collect_signals/main.go
+++ b/cmd/collect_signals/main.go
@@ -123,8 +123,8 @@ func main() {
 	scoreColumnName := generateScoreColumnName(s)
 
 	// Complete the validation of args
-	if flag.NArg() != 2 {
-		logger.Error("Must have one input file and one output file specified.")
+	if flag.NArg() != 1 {
+		logger.Error("Must have an input file specified.")
 		os.Exit(2)
 	}
 

--- a/cmd/collect_signals/main.go
+++ b/cmd/collect_signals/main.go
@@ -53,7 +53,7 @@ var (
 func init() {
 	flag.Var(&logLevel, "log", "set the `level` of logging.")
 	flag.TextVar(&logEnv, "log-env", log.DefaultEnv, "set logging `env`.")
-	outfile.DefineFlags(flag.CommandLine, "force", "append", "OUT_FILE")
+	outfile.DefineFlags(flag.CommandLine, "out", "force", "append", "OUT_FILE")
 	flag.Usage = func() {
 		cmdName := path.Base(os.Args[0])
 		w := flag.CommandLine.Output()
@@ -151,7 +151,6 @@ func main() {
 	}
 
 	inFilename := flag.Args()[0]
-	outFilename := flag.Args()[1]
 
 	// Open the in-file for reading
 	r, err := infile.Open(context.Background(), inFilename)
@@ -165,10 +164,9 @@ func main() {
 	defer r.Close()
 
 	// Open the out-file for writing
-	w, err := outfile.Open(context.Background(), outFilename)
+	w, err := outfile.Open(context.Background())
 	if err != nil {
 		logger.With(
-			zap.String("filename", outFilename),
 			zap.Error(err),
 		).Error("Failed to open file for output")
 		os.Exit(2)

--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -12,8 +12,8 @@ $ export GITHUB_TOKEN=ghp_x  # Personal Access Token Goes Here
 $ gcloud login --update-adc  # Sign-in to GCP
 $ criticality_score \
     -workers=1 \
-    github_projects.txt \
-    signals.csv
+    -out=signals.csv \
+    github_projects.txt
 ```
 
 ## Install
@@ -194,7 +194,7 @@ Rather than installing the binary, use `go run` to run the command.
 For example:
 
 ```shell
-$ go run ./cmd/criticality_score [FLAGS]... IN_FILE... OUT_FILE
+$ go run ./cmd/criticality_score [FLAGS]... IN_FILE...
 ```
 
 Pass in a single repo using echo to quickly test signal collection, for example:
@@ -203,5 +203,5 @@ Pass in a single repo using echo to quickly test signal collection, for example:
 $ echo "https://github.com/django/django" | \
     go run ./cmd/criticality_score \
       -log=debug \
-      - -
+      -
 ```

--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -25,14 +25,14 @@ $ go install github.com/ossf/criticality_score/cmd/criticality_score
 ## Usage
 
 ```shell
-$ criticality_score [FLAGS]... IN_FILE OUT_FILE
+$ criticality_score [FLAGS]... IN_FILE
 ```
 
 Project repository URLs are read from the specified `IN_FILE`. If `-` is passed
 in as an `IN_FILE` URLs will read from STDIN.
 
-Results are written in CSV format to `OUT_FILE`. If `OUT_FILE` is `-` the
-results will be written to STDOUT.
+Results are written in CSV format the output. By default `stdout` is used for
+output.
 
 `FLAGS` are optional. See below for documentation.
 
@@ -104,6 +104,7 @@ See more on GCP
 
 #### Output flags
 
+- `-out FILE` specify the `FILE` to use for output. By default `stdout` is used.
 - `-append` appends output to `FILE` if it already exists.
 - `-force` overwrites `FILE` if it already exists and `-append` is not set.
 

--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -31,7 +31,7 @@ $ criticality_score [FLAGS]... IN_FILE
 Project repository URLs are read from the specified `IN_FILE`. If `-` is passed
 in as an `IN_FILE` URLs will read from STDIN.
 
-Results are written in CSV format the output. By default `stdout` is used for
+Results are written in CSV format to the output. By default `stdout` is used for
 output.
 
 `FLAGS` are optional. See below for documentation.

--- a/cmd/criticality_score/main.go
+++ b/cmd/criticality_score/main.go
@@ -52,27 +52,6 @@ var (
 	logEnv                log.Env
 )
 
-// INPUT
-// script REPO [REPO...]
-// script -file filepath
-// script (reads from STDIN)
-
-// changes:
-// IN_FILE -> -repos file
-// STDIN -> "dash" arg (consistency, and to ensure we have an arg to catch errors)
-// -> args = repos
-// alt 1: -repo X -repo X -repo X
-// alt 2: -repos X Y Z (i.e. flag changes bare args to be repos)
-// alt 3: implicit input file detection (if 1 arg and file with name exists use it)
-// alt 4: alt 3 + optional args that force the behavior if it is ambiguous
-
-// How does this affect scorer...
-// OUT_FILE -> -out file
-// IN_FILE -> arg  -- this is inconsistent
-
-// How does this affect enumeration
-// OUT_FILE -> -out file (no args)
-
 func init() {
 	flag.Var(&logLevel, "log", "set the `level` of logging.")
 	flag.TextVar(&logEnv, "log-env", log.DefaultEnv, "set logging `env`.")
@@ -146,8 +125,8 @@ func main() {
 	scoreColumnName := generateScoreColumnName(s)
 
 	// Complete the validation of args
-	if flag.NArg() != 2 {
-		logger.Error("Must have one input file and one output file specified.")
+	if flag.NArg() != 1 {
+		logger.Error("Must have an input file specified.")
 		os.Exit(2)
 	}
 

--- a/cmd/enumerate_github/README.md
+++ b/cmd/enumerate_github/README.md
@@ -13,7 +13,7 @@ $ enumerate_github \
     -start 2008-01-01 \
     -min-stars=10 \
     -workers=1 \
-    github_projects.txt
+    -out=github_projects.txt
 ```
 
 ## Install
@@ -25,10 +25,11 @@ $ go install github.com/ossf/criticality_score/cmd/enumerate_github
 ## Usage
 
 ```shell
-$ enumerate_github [FLAGS]... FILE
+$ enumerate_github [FLAGS]...
 ```
 
-The URL for each repository is written to `FILE`. If `FILE` is `-` the results will be written to STDOUT.
+The URL for each repository is written to the output. By default `stdout` is used
+for output.
 
 `FLAGS` are optional. See below for documentation.
 
@@ -50,8 +51,13 @@ $ export GITHUB_TOKEN=ghp_abc,ghp_123
 
 #### Output flags
 
+- `-out FILE` specify the `FILE` to use for output. By default `stdout` is used.
 - `-append` appends output to `FILE` if it already exists.
 - `-force` overwrites `FILE` if it already exists and `-append` is not set.
+- `-format {text|scorecard}` indicates the format to use for output. `text` is
+  used by default and consists of one URL per line. `scorecard` outputs a CSV
+  file compatible with the [scorecard](https://github.com/ossf/scorecard)
+  project.
 
 If `FILE` exists and neither `-append` nor `-force` is set the command will fail.
 
@@ -119,7 +125,7 @@ Rather than installing the binary, use `go run` to run the command.
 For example:
 
 ```shell
-$ go run ./cmd/enumerate_github [FLAGS]... FILE
+$ go run ./cmd/enumerate_github [FLAGS]...
 ```
 
 Limiting the data allows for runs to be completed quickly. For example:
@@ -129,6 +135,5 @@ $ go run ./cmd/enumerate_github \
     -log=debug \
     -start=2022-06-14 \
     -end=2022-06-21 \
-    -min-stars=20 \
-    -
+    -min-stars=20
 ```

--- a/cmd/enumerate_github/main.go
+++ b/cmd/enumerate_github/main.go
@@ -72,6 +72,7 @@ var (
 		"CRITICALITY_SCORE_WORKERS":            "workers",
 		"CRITICALITY_SCORE_START_DATE":         "start",
 		"CRITICALITY_SCORE_END_DATE":           "end",
+		"CRITICALITY_SCORE_OUTFILE":            "out",
 		"CRITICALITY_SCORE_OUTFILE_FORCE":      "force",
 		"CRITICALITY_SCORE_QUERY":              "query",
 		"CRITICALITY_SCORE_STARS_MIN":          "min-stars",
@@ -107,13 +108,13 @@ func init() {
 	flag.Var(&logLevel, "log", "set the `level` of logging.")
 	flag.TextVar(&format, "format", repowriter.WriterTypeText, "set output file `format`.")
 	flag.TextVar(&logEnv, "log-env", log.DefaultEnv, "set logging `env`.")
-	outfile.DefineFlags(flag.CommandLine, "force", "append", "FILE")
+	outfile.DefineFlags(flag.CommandLine, "out", "force", "append", "FILE")
 	flag.Usage = func() {
 		cmdName := path.Base(os.Args[0])
 		w := flag.CommandLine.Output()
-		fmt.Fprintf(w, "Usage:\n  %s [FLAGS]... FILE\n\n", cmdName)
+		fmt.Fprintf(w, "Usage:\n  %s [FLAGS]...\n\n", cmdName)
 		fmt.Fprintf(w, "Enumerates GitHub repositories between -start date and -end date, with -min-stars\n")
-		fmt.Fprintf(w, "or higher. Writes each repository URL on a separate line to FILE.\n")
+		fmt.Fprintf(w, "or higher. Writes each repository URL in the specified format.\n")
 		fmt.Fprintf(w, "\nFlags:\n")
 		flag.PrintDefaults()
 	}
@@ -201,7 +202,7 @@ func main() {
 	).Info("Preparing output file")
 
 	// Open the output file
-	out, err := outfile.Open(context.Background(), outFilename)
+	out, err := outfile.Open(context.Background())
 	if err != nil {
 		// File failed to open
 		logger.Error("Failed to open output file", zap.Error(err))

--- a/cmd/scorer/README.md
+++ b/cmd/scorer/README.md
@@ -10,8 +10,8 @@ The input of this tool is usually the output of the `collect_signals` tool.
 ```shell
 $ scorer \
     -config config/scorer/original_pike.yml \
-    raw_signals.txt \
-    scored_signals.txt
+    -out=scored_signals.txt \
+    raw_signals.txt
 ```
 
 ## Install
@@ -132,7 +132,7 @@ Rather than installing the binary, use `go run` to run the command.
 For example:
 
 ```shell
-$ go run ./cmd/scorer [FLAGS]... IN_FILE OUT_FILE
+$ go run ./cmd/scorer [FLAGS]... IN_FILE
 ```
 
 Use STDIN and STDOUT on a subset of data for fast iteration. For example:
@@ -140,5 +140,5 @@ Use STDIN and STDOUT on a subset of data for fast iteration. For example:
 ```shell
 $ head -10 raw_signals.csv | go run ./cmd/scorer \
     -config config/scorer/original_pike.yml \
-    - -
+    -
 ```

--- a/cmd/scorer/README.md
+++ b/cmd/scorer/README.md
@@ -23,14 +23,14 @@ $ go install github.com/ossf/criticality_score/cmd/scorer
 ## Usage
 
 ```shell
-$ scorer [FLAGS]... IN_FILE OUT_FILE
+$ scorer [FLAGS]... IN_FILE
 ```
 
 Raw signals are read as CSV from `IN_FILE`. If `-` is passed in for `IN_FILE`
 raw signal data will read from STDIN rather than a file.
 
-Results are re-written in CSV format to `OUT_FILE`. If `OUT_FILE` is `-` the
-results will be written to STDOUT. Results are sorted in descending score order.
+Results are re-written in CSV format to the output in descending score order.
+By default `stdout` is used for output.
 
 The `-config` flag is required. All other `FLAGS` are optional.
 See below for documentation.
@@ -39,6 +39,7 @@ See below for documentation.
 
 #### Output flags
 
+- `-out FILE` specify the `FILE` to use for output. By default `stdout` is used.
 - `-append` appends output to `OUT_FILE` if it already exists.
 - `-force` overwrites `OUT_FILE` if it already exists and `-append` is not set.
 

--- a/cmd/scorer/main.go
+++ b/cmd/scorer/main.go
@@ -63,7 +63,7 @@ var (
 func init() {
 	flag.Var(&logLevel, "log", "set the `level` of logging.")
 	flag.TextVar(&logEnv, "log-env", log.DefaultEnv, "set logging `env`.")
-	outfile.DefineFlags(flag.CommandLine, "force", "append", "OUT_FILE") // TODO: add the ability to disable "append"
+	outfile.DefineFlags(flag.CommandLine, "out", "force", "append", "OUT_FILE") // TODO: add the ability to disable "append"
 	flag.Usage = func() {
 		cmdName := path.Base(os.Args[0])
 		w := flag.CommandLine.Output()
@@ -116,7 +116,6 @@ func main() {
 		os.Exit(2)
 	}
 	inFilename := flag.Args()[0]
-	outFilename := flag.Args()[1]
 
 	// Open the in-file for reading
 	var r *csv.Reader
@@ -132,11 +131,10 @@ func main() {
 	r = csv.NewReader(fr)
 
 	// Open the out-file for writing
-	fw, err := outfile.Open(context.Background(), outFilename)
+	fw, err := outfile.Open(context.Background())
 	if err != nil {
 		logger.With(
 			zap.Error(err),
-			zap.String("filename", outFilename),
 		).Error("Failed to open file for output")
 		os.Exit(2)
 	}

--- a/cmd/scorer/main.go
+++ b/cmd/scorer/main.go
@@ -111,8 +111,8 @@ func main() {
 	}
 	defer logger.Sync()
 
-	if flag.NArg() != 2 {
-		logger.Error("Must have an input file and an output file specified")
+	if flag.NArg() != 1 {
+		logger.Error("Must have an input file specified.")
 		os.Exit(2)
 	}
 	inFilename := flag.Args()[0]

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,8 +1,7 @@
-github.com/Abirdcfly/dupword v0.0.7 h1:z14n0yytA3wNO2gpCD/jVtp/acEXPGmYu0esewpBt6Q=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
-github.com/kkHAIKE/contextcheck v1.1.2 h1:BYUSG/GhMhqVz//yjl8IkBDlMEws+9DtCmkz18QO1gg=
+github.com/google/go-github/v38 v38.1.0 h1:C6h1FkaITcBFK7gAmq4eFzt6gbhEhk7L5z6R3Uva+po=
+github.com/jszwec/csvutil v1.6.0 h1:QORXquCT0t8nUKD7utAD4HDmQMgG0Ir9WieZXzpa7ms=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
-github.com/maratori/testableexamples v1.0.0 h1:dU5alXRrD8WKSjOUnmJZuzdxWOEQ57+7s93SLMxb2vI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -11,9 +10,7 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/timonwong/loggercheck v0.9.3 h1:ecACo9fNiHxX4/Bc02rW2+kaJIAMAes7qJ7JKxt0EZI=
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/sys v0.0.0-20220915200043-7b5979e65e41 h1:ohgcoMbSofXygzo6AD2I1kz3BFmW1QArPYTtwEM3UXc=
 google.golang.org/api v0.81.0 h1:o8WF5AvfidafWbFjsRyupxyEQJNUWxLZJCK5NXrxZZ8=

--- a/infra/k8s/enumerate_github.yaml
+++ b/infra/k8s/enumerate_github.yaml
@@ -27,13 +27,14 @@ spec:
           containers:
           - name: enumerate-github
             image: gcr.io/openssf/criticality-score-enumerate-github:latest
-            args: ["gs://ossf-criticality-score-url-data/[[runid]]/github.csv"]
             imagePullPolicy: Always
             env:
             - name: GITHUB_AUTH_SERVER
               value: "10.4.4.210:80"
             - name: CRITICALITY_SCORE_LOG_ENV
               value: "gcp"
+            - name: CRITICALITY_SCORE_OUTFILE
+              value: "gs://ossf-criticality-score-url-data/[[runid]]/github.csv"
             - name: CRITICALITY_SCORE_OUTFILE_FORCE
               value: "1"
             - name: CRITICALITY_SCORE_STARS_MIN

--- a/infra/test/docker-compose.yml
+++ b/infra/test/docker-compose.yml
@@ -42,8 +42,8 @@ services:
 
   enumerate-github:
     image: criticality-score-enumerate-github:latest
-    command: s3://criticality_score/enumeration/[[runid]]/github.txt?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
     environment:
+      CRITICALITY_SCORE_OUTFILE: s3://criticality_score/enumeration/[[runid]]/github.txt?endpoint=minio:9000&disableSSL=true&s3ForcePathStyle=true
       CRITICALITY_SCORE_OUTFILE_FORCE: 1
       CRITICALITY_SCORE_STARS_MIN: ${CRITICALITY_SCORE_STARS_MIN:-100}
       CRITICALITY_SCORE_START_DATE: ${CRITICALITY_SCORE_START_DATE}

--- a/internal/outfile/outfile.go
+++ b/internal/outfile/outfile.go
@@ -50,7 +50,7 @@ type writeCloserWrapper struct {
 	name string
 }
 
-// Name implements the NameWriteCloser interface
+// Name implements the NameWriteCloser interface.
 func (w *writeCloserWrapper) Name() string {
 	if w == nil {
 		return ""
@@ -59,12 +59,12 @@ func (w *writeCloserWrapper) Name() string {
 }
 
 type Opener struct {
+	FilenameTransform FilenameTransform
 	fileOpener        fileOpenFunc
 	filename          string
 	forceFlag         string
 	force             bool
 	append            bool
-	FilenameTransform FilenameTransform
 	Perm              os.FileMode
 }
 

--- a/internal/outfile/outfile.go
+++ b/internal/outfile/outfile.go
@@ -33,21 +33,48 @@ import (
 // fileOpenFunc makes it possible to mock os.OpenFile() for testing.
 type fileOpenFunc func(string, int, os.FileMode) (*os.File, error)
 
+// A FilenameTransform applies a transform to the filename before it used to
+// open a file.
+type FilenameTransform func(string) string
+
+// NameWriteCloser implements the io.WriteCloser interface, but also allows a
+// a name to be returned so that the object can be identified.
+type NameWriteCloser interface {
+	// Name returns a name for the Writer.
+	Name() string
+	io.WriteCloser
+}
+
+type writeCloserWrapper struct {
+	io.WriteCloser
+	name string
+}
+
+// Name implements the NameWriteCloser interface
+func (w *writeCloserWrapper) Name() string {
+	if w == nil {
+		return ""
+	}
+	return w.name
+}
+
 type Opener struct {
-	fileOpener fileOpenFunc
-	filename   string
-	forceFlag  string
-	force      bool
-	append     bool
-	Perm       os.FileMode
+	fileOpener        fileOpenFunc
+	filename          string
+	forceFlag         string
+	force             bool
+	append            bool
+	FilenameTransform FilenameTransform
+	Perm              os.FileMode
 }
 
 // CreateOpener creates an Opener and defines the sepecified flags fileFlag, forceFlag and appendFlag.
 func CreateOpener(fs *flag.FlagSet, fileFlag, forceFlag, appendFlag, fileHelpName string) *Opener {
 	o := &Opener{
-		Perm:       0o666,
-		fileOpener: os.OpenFile,
-		forceFlag:  forceFlag,
+		Perm:              0o666,
+		FilenameTransform: func(f string) string { return f },
+		fileOpener:        os.OpenFile,
+		forceFlag:         forceFlag,
 	}
 	fs.StringVar(&(o.filename), fileFlag, "", fmt.Sprintf("use the file `%s` for output. Defaults to stdout if not set.", fileHelpName))
 	fs.BoolVar(&(o.force), forceFlag, false, fmt.Sprintf("overwrites %s if it already exists and -%s is not set.", fileHelpName, appendFlag))
@@ -55,11 +82,11 @@ func CreateOpener(fs *flag.FlagSet, fileFlag, forceFlag, appendFlag, fileHelpNam
 	return o
 }
 
-func (o *Opener) openFile(filename string, extraFlags int) (io.WriteCloser, error) {
+func (o *Opener) openFile(filename string, extraFlags int) (NameWriteCloser, error) {
 	return o.fileOpener(filename, os.O_WRONLY|os.O_SYNC|os.O_CREATE|extraFlags, o.Perm)
 }
 
-func (o *Opener) openBlobStore(ctx context.Context, u *url.URL) (io.WriteCloser, error) {
+func (o *Opener) openBlobStore(ctx context.Context, u *url.URL) (NameWriteCloser, error) {
 	if o.append || !o.force {
 		return nil, fmt.Errorf("blob store must use -%s flag", o.forceFlag)
 	}
@@ -78,10 +105,14 @@ func (o *Opener) openBlobStore(ctx context.Context, u *url.URL) (io.WriteCloser,
 	if err != nil {
 		return nil, fmt.Errorf("failed creating writer for %s/%s: %w", bucket, prefix, err)
 	}
-	return w, nil
+	return &writeCloserWrapper{
+		WriteCloser: w,
+		name:        u.String(),
+	}, nil
 }
 
-// Open opens and returns a file for output with the filename set by the fileFlag.ß
+// Open opens and returns a file for output with the filename set by the fileFlag,
+// applying any transform set in FilenameTransform.
 //
 // If filename is empty/unset, os.Stdout will be used.
 // If filename does not exist, it will be created with the mode set in o.Perm.
@@ -94,33 +125,34 @@ func (o *Opener) openBlobStore(ctx context.Context, u *url.URL) (io.WriteCloser,
 //     truncated.
 //   - if neither forceFlag nor appendFlag are set an error will be
 //     returned.
-func (o *Opener) Open(ctx context.Context) (io.WriteCloser, error) {
-	if o.filename == "" {
+func (o *Opener) Open(ctx context.Context) (NameWriteCloser, error) {
+	f := o.FilenameTransform(o.filename)
+	if f == "" {
 		return os.Stdout, nil
-	} else if u, e := url.Parse(o.filename); e == nil && u.IsAbs() {
+	} else if u, e := url.Parse(f); e == nil && u.IsAbs() {
 		return o.openBlobStore(ctx, u)
 	}
 	switch {
 	case o.append:
-		return o.openFile(o.filename, os.O_APPEND)
+		return o.openFile(f, os.O_APPEND)
 	case o.force:
-		return o.openFile(o.filename, os.O_TRUNC)
+		return o.openFile(f, os.O_TRUNC)
 	default:
-		return o.openFile(o.filename, os.O_EXCL)
+		return o.openFile(f, os.O_EXCL)
 	}
 }
 
-var defaultOpener *Opener
+var DefaultOpener *Opener
 
 // DefineFlags is a wrapper around CreateOpener for updating a default instance
 // of Opener.
 func DefineFlags(fs *flag.FlagSet, fileFlag, forceFlag, appendFlag, fileHelpName string) {
-	defaultOpener = CreateOpener(fs, fileFlag, forceFlag, appendFlag, fileHelpName)
+	DefaultOpener = CreateOpener(fs, fileFlag, forceFlag, appendFlag, fileHelpName)
 }
 
 // Open is a wrapper around Opener.Open for the default instance of Opener.
 //
 // Must only be called after DefineFlags.
-func Open(ctx context.Context) (io.WriteCloser, error) {
-	return defaultOpener.Open(ctx)
+func Open(ctx context.Context) (NameWriteCloser, error) {
+	return DefaultOpener.Open(ctx)
 }


### PR DESCRIPTION
Use -out=file to specify the output file, rather than as a positional arg.

This change is important for simplifying the CLI for `criticality_score`, so it was applied across all the commands.

The following changes were made to support this:
- A flag was added to outfile for the filename
- The capability to transform filenames was added to outfile (to support run-ids in enumeration)
- All the READMEs were updated.

This changes moves us closer to deprecating the Python version