### PR TITLE
Add a cloudbuild.yaml for collect_signals worker.

### DIFF
--- a/infra/cloudbuild/collect_signals/cloudbuild.yaml
+++ b/infra/cloudbuild/collect_signals/cloudbuild.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Criticality Score Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.',
+  '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
+  '-t', 'gcr.io/openssf/criticality-score-collect-signals:$COMMIT_SHA',
+  '-t', 'gcr.io/openssf/criticality-score-collect-signals:latest',
+  '-f', 'cmd/collect_signals/Dockerfile']
+images: ['gcr.io/openssf/criticality-score-collect-signals']


### PR DESCRIPTION
This automatically builds the collect_signals image we need to run criticality score in production.

Signed-off-by: Caleb Brown <calebbrown@google.com>