### PR TITLE
Add JSON support for outputting signals.

### DIFF
--- a/cmd/collect_signals/worker.go
+++ b/cmd/collect_signals/worker.go
@@ -22,6 +22,7 @@ type collectWorker struct {
 	c               *collector.Collector
 	s               *scorer.Scorer
 	scoreColumnName string
+	writerType      signalio.WriterType
 }
 
 // Process implements the worker.Worker interface.
@@ -42,7 +43,7 @@ func (w *collectWorker) Process(ctx context.Context, req *data.ScorecardBatchReq
 		extras = append(extras, w.scoreColumnName)
 	}
 	var output bytes.Buffer
-	out := signalio.CsvWriter(&output, w.c.EmptySets(), extras...)
+	out := w.writerType.New(&output, w.c.EmptySets(), extras...)
 
 	// Iterate through the repos in this shard.
 	for _, repo := range req.GetRepos() {
@@ -125,7 +126,7 @@ func getScorer(logger *zap.Logger, scoringEnabled bool, scoringConfigFile string
 	return s, nil
 }
 
-func NewWorker(ctx context.Context, logger *zap.Logger, scoringEnabled bool, scoringConfigFile, scoringColumn string, collectOpts []collector.Option) (*collectWorker, error) {
+func NewWorker(ctx context.Context, logger *zap.Logger, writerType signalio.WriterType, scoringEnabled bool, scoringConfigFile, scoringColumn string, collectOpts []collector.Option) (*collectWorker, error) {
 	logger.Info("Initializing worker")
 
 	c, err := collector.New(ctx, logger, collectOpts...)
@@ -149,6 +150,7 @@ func NewWorker(ctx context.Context, logger *zap.Logger, scoringEnabled bool, sco
 		c:               c,
 		s:               s,
 		scoreColumnName: scoringColumn,
+		writerType:      writerType,
 	}, nil
 }
 

--- a/cmd/criticality_score/main.go
+++ b/cmd/criticality_score/main.go
@@ -48,12 +48,14 @@ var (
 	workersFlag           = flag.Int("workers", 1, "the total number of concurrent workers to use.")
 	logLevel              = defaultLogLevel
 	logEnv                log.Env
+	formatType            signalio.WriterType
 )
 
 // initFlags prepares any runtime flags, usage information and parses the flags.
 func initFlags() {
 	flag.Var(&logLevel, "log", "set the `level` of logging.")
 	flag.TextVar(&logEnv, "log-env", log.DefaultEnv, "set logging `env`.")
+	flag.TextVar(&formatType, "format", signalio.WriterTypeCSV, "set the output format.")
 	outfile.DefineFlags(flag.CommandLine, "out", "force", "append", "OUTFILE")
 	flag.Usage = func() {
 		cmdName := path.Base(os.Args[0])
@@ -181,7 +183,7 @@ func main() {
 	if s != nil {
 		extras = append(extras, scoreColumnName)
 	}
-	out := signalio.CsvWriter(w, c.EmptySets(), extras...)
+	out := formatType.New(w, c.EmptySets(), extras...)
 
 	// Start the workers that process a channel of repo urls.
 	repos := make(chan *url.URL)

--- a/internal/collector/signal/signal.go
+++ b/internal/collector/signal/signal.go
@@ -36,7 +36,7 @@ const (
 
 	// namespaceLegacy is an internal namespace used for fields that provide
 	// compatibility with the legacy python implementation.
-	namespaceLegacy Namespace = "legacy"
+	NamespaceLegacy Namespace = "legacy"
 
 	// The following constants are used while parsing the tags for the struct
 	// fields in a Set.
@@ -213,7 +213,7 @@ func SetFields(s Set, namespace bool) []string {
 	legacyPrefix := ""
 	if namespace {
 		prefix = fmt.Sprintf("%s%c", s.Namespace(), nameSeparator)
-		legacyPrefix = fmt.Sprintf("%s%c", namespaceLegacy, nameSeparator)
+		legacyPrefix = fmt.Sprintf("%s%c", NamespaceLegacy, nameSeparator)
 	}
 	_ = iterSetFields(s, func(f *fieldConfig, _ any) error {
 		if f.legacy {
@@ -251,5 +251,27 @@ func SetAsMap(s Set, namespace bool) map[string]any {
 	for i := range fs {
 		m[fs[i]] = vs[i]
 	}
+	return m
+}
+
+// SetAsMapWithNamespace returns a map where the outer map contains keys
+// corresponding to the namespace, and each inner map contains each field name
+// mapped to the value of the field.
+func SetAsMapWithNamespace(s Set) map[string]map[string]any {
+	m := make(map[string]map[string]any)
+	_ = iterSetFields(s, func(f *fieldConfig, v any) error {
+		// Determine which namespace to use.
+		ns := s.Namespace().String()
+		if f.legacy {
+			ns = NamespaceLegacy.String()
+		}
+		innerM, ok := m[ns]
+		if !ok {
+			innerM = make(map[string]any)
+			m[ns] = innerM
+		}
+		innerM[f.name] = v
+		return nil
+	})
 	return m
 }

--- a/internal/signalio/csv.go
+++ b/internal/signalio/csv.go
@@ -46,7 +46,7 @@ func headerFromSignalSets(sets []signal.Set, extra []string) []string {
 	return hs
 }
 
-func CsvWriter(w io.Writer, emptySets []signal.Set, extra ...string) Writer {
+func CSVWriter(w io.Writer, emptySets []signal.Set, extra ...string) Writer {
 	return &csvWriter{
 		header: headerFromSignalSets(emptySets, extra),
 		w:      csv.NewWriter(w),

--- a/internal/signalio/json.go
+++ b/internal/signalio/json.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Criticality Score Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalio
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/ossf/criticality_score/internal/collector/signal"
+)
+
+type jsonWriter struct {
+	encoder *json.Encoder
+
+	// Prevents concurrent writes to w.
+	mu sync.Mutex
+}
+
+func JSONWriter(w io.Writer) Writer {
+	e := json.NewEncoder(w)
+	e.SetIndent("", "")
+	return &jsonWriter{
+		encoder: e,
+	}
+}
+
+// WriteSignals implements the Writer interface.
+func (w *jsonWriter) WriteSignals(signals []signal.Set, extra ...Field) error {
+	data := make(map[string]any)
+	for _, s := range signals {
+		m := signal.SetAsMapWithNamespace(s)
+
+		// Merge m with data
+		for ns, innerM := range m {
+			d, ok := data[ns]
+			if !ok {
+				d = make(map[string]any)
+				data[ns] = d
+			}
+			nsData, ok := d.(map[string]any)
+			if !ok {
+				return fmt.Errorf("failed to get map for namespace: %s", ns)
+			}
+			for k, v := range innerM {
+				nsData[k] = v
+			}
+		}
+	}
+	for _, f := range extra {
+		data[f.Key] = f.Value
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.encoder.Encode(data)
+}

--- a/internal/signalio/type.go
+++ b/internal/signalio/type.go
@@ -1,0 +1,79 @@
+// Copyright 2022 Criticality Score Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalio
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/ossf/criticality_score/internal/collector/signal"
+)
+
+type WriterType int
+
+const (
+	WriterTypeCSV = WriterType(iota)
+	WriterTypeJSON
+)
+
+var ErrorUnknownWriterType = errors.New("unknown writer type")
+
+// String implements the fmt.Stringer interface.
+func (t WriterType) String() string {
+	text, err := t.MarshalText()
+	if err != nil {
+		return ""
+	}
+	return string(text)
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+func (t WriterType) MarshalText() ([]byte, error) {
+	switch t {
+	case WriterTypeCSV:
+		return []byte("csv"), nil
+	case WriterTypeJSON:
+		return []byte("json"), nil
+	default:
+		return []byte{}, ErrorUnknownWriterType
+	}
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+func (t *WriterType) UnmarshalText(text []byte) error {
+	switch {
+	case bytes.Equal(text, []byte("csv")):
+		*t = WriterTypeCSV
+	case bytes.Equal(text, []byte("json")):
+		*t = WriterTypeJSON
+	default:
+		return ErrorUnknownWriterType
+	}
+	return nil
+}
+
+// New will return a new instance of the corresponding implementation of
+// Writer for the given WriterType.
+func (t *WriterType) New(w io.Writer, emptySets []signal.Set, extra ...string) Writer {
+	switch *t {
+	case WriterTypeCSV:
+		return CSVWriter(w, emptySets, extra...)
+	case WriterTypeJSON:
+		return JSONWriter(w)
+	default:
+		return nil
+	}
+}

--- a/internal/signalio/type_test.go
+++ b/internal/signalio/type_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Criticality Score Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalio_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ossf/criticality_score/internal/signalio"
+)
+
+func TestTypeString(t *testing.T) {
+	//nolint:govet
+	tests := []struct {
+		name       string
+		writerType signalio.WriterType
+		want       string
+	}{
+		{name: "csv", writerType: signalio.WriterTypeCSV, want: "csv"},
+		{name: "json", writerType: signalio.WriterTypeJSON, want: "json"},
+		{name: "unknown", writerType: signalio.WriterType(10), want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.writerType.String()
+			if got != test.want {
+				t.Fatalf("String() == %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestTypeMarshalText(t *testing.T) {
+	//nolint:govet
+	tests := []struct {
+		name       string
+		writerType signalio.WriterType
+		want       string
+		err        error
+	}{
+		{name: "csv", writerType: signalio.WriterTypeCSV, want: "csv"},
+		{name: "json", writerType: signalio.WriterTypeJSON, want: "json"},
+		{name: "unknown", writerType: signalio.WriterType(10), want: "", err: signalio.ErrorUnknownWriterType},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.writerType.MarshalText()
+			if err != nil && !errors.Is(err, test.err) {
+				t.Fatalf("MarhsalText() == %v, want %v", err, test.err)
+			}
+			if err == nil {
+				if test.err != nil {
+					t.Fatalf("MarshalText() return nil error, want %v", test.err)
+				}
+				if string(got) != test.want {
+					t.Fatalf("MarhsalText() == %s, want %s", got, test.want)
+				}
+			}
+		})
+	}
+}
+
+func TestTypeUnmarshalText(t *testing.T) {
+	//nolint:govet
+	tests := []struct {
+		input string
+		want  signalio.WriterType
+		err   error
+	}{
+		{input: "csv", want: signalio.WriterTypeCSV},
+		{input: "json", want: signalio.WriterTypeJSON},
+		{input: "", want: 0, err: signalio.ErrorUnknownWriterType},
+		{input: "unknown", want: 0, err: signalio.ErrorUnknownWriterType},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			var got signalio.WriterType
+			err := got.UnmarshalText([]byte(test.input))
+			if err != nil && !errors.Is(err, test.err) {
+				t.Fatalf("UnmarshalText() == %v, want %v", err, test.err)
+			}
+			if err == nil {
+				if test.err != nil {
+					t.Fatalf("MarshalText() return nil error, want %v", test.err)
+				}
+				if got != test.want {
+					t.Fatalf("UnmarshalText() parsed %d, want %d", int(got), int(test.want))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Scorecard transfer expects to see JSON to import.

I was planning to add this anyway, but the BQ load just expidited this.

All values are aggregated into objects based on their namespace.

Signed-off-by: Caleb Brown <calebbrown@google.com>