### PR TITLE
Add support for a text format similar to OG python implementation.

### DIFF
--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -13,6 +13,7 @@ $ gcloud login --update-adc  # Sign-in to GCP
 $ criticality_score \
     -workers=1 \
     -out=signals.csv \
+    -format=csv \
     github_projects.txt
 ```
 
@@ -108,7 +109,10 @@ See more on GCP
 
 #### Output flags
 
-- `-out OUTFILE` specify the `OUTFILE` to use for output. By default `stdout` is used.
+- `-format string` specifies the format to use when writing output. Can be
+  `text` (default), `csv` or `json`.
+- `-out OUTFILE` specify the `OUTFILE` to use for output. By default `stdout`
+  is used.
 - `-append` appends output to `OUTFILE` if it already exists.
 - `-force` overwrites `OUTFILE` if it already exists and `-append` is not set.
 
@@ -123,6 +127,16 @@ fail.
 
 - `-depsdev-disable` disables the collection of signals from deps.dev.
 - `-depsdev-dataset string` the BigQuery dataset name to use. Default is `depsdev_analysis`.
+
+#### Scoring flags
+
+- `-scoring-disable` disables the generation of scores.
+- `-scoring-config CONFIG_FILE` specify the `CONFIG_FILE` to use to define how
+  scores are calculated. See `/config/scorer/` for some valid configs. By
+  default `/config/scorer/original_pike.yml` is used.
+- `-scoring-column` overrides the name of the column used to store the score.
+  By default the column is named `default_score`, and if `-scoring-config` is 
+  resent the column's name will be based on the config filename.
 
 #### Misc flags
 
@@ -151,13 +165,15 @@ the quota for a single token in about 30-40 minutes.
 
 1. Spin up a compute instance in GCE with lots of RAM and fast network:
     - Uses GCP's fast/reliable internet connectivity.
-    - Reduces latency and costs for querying BigQuery data (and perhaps 
+    - Reduces latency and costs for querying BigQuery data (and perhaps
       GitHub's data too).
-   - Prevents downtime due to local IT failures.
+    - Prevents downtime due to local IT failures.
 1. Shard the input repository list and run multiple instances on different
    hosts with different GitHub tokens:
     - Ensures work progresses even if one instance stops.
     - Provides additional compute and network resources.
+1. Take a look at `collect_signals` and the `\infra\` for a productionized
+   implementation.
 
 ### Q: How do I restart after a failure?
 

--- a/cmd/criticality_score/main.go
+++ b/cmd/criticality_score/main.go
@@ -55,7 +55,7 @@ var (
 func initFlags() {
 	flag.Var(&logLevel, "log", "set the `level` of logging.")
 	flag.TextVar(&logEnv, "log-env", log.DefaultEnv, "set logging `env`.")
-	flag.TextVar(&formatType, "format", signalio.WriterTypeCSV, "set the output format.")
+	flag.TextVar(&formatType, "format", signalio.WriterTypeText, "set the output format. Choices are text, json or csv.")
 	outfile.DefineFlags(flag.CommandLine, "out", "force", "append", "OUTFILE")
 	flag.Usage = func() {
 		cmdName := path.Base(os.Args[0])

--- a/internal/signalio/helpers.go
+++ b/internal/signalio/helpers.go
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalio
+
+import (
+	"fmt"
+
+	"github.com/ossf/criticality_score/internal/collector/signal"
+)
+
+func fieldsFromSignalSets(sets []signal.Set, extra []string) []string {
+	var fields []string
+	for _, s := range sets {
+		if err := signal.ValidateSet(s); err != nil {
+			panic(err)
+		}
+		fields = append(fields, signal.SetFields(s, true)...)
+	}
+	// Append all the extra fields
+	fields = append(fields, extra...)
+	return fields
+}
+
+func marshalToMap(signals []signal.Set, extra ...Field) (map[string]string, error) {
+	values := make(map[string]string)
+	for _, s := range signals {
+		// Get all of the signal data from the set and serialize it.
+		for k, v := range signal.SetAsMap(s, true) {
+			if s, err := marshalValue(v); err != nil {
+				return nil, fmt.Errorf("failed to write field %s: %w", k, err)
+			} else {
+				values[k] = s
+			}
+		}
+	}
+	for _, f := range extra {
+		if s, err := marshalValue(f.Value); err != nil {
+			return nil, fmt.Errorf("failed to write field %s: %w", f.Key, err)
+		} else {
+			values[f.Key] = s
+		}
+	}
+	return values, nil
+}

--- a/internal/signalio/text.go
+++ b/internal/signalio/text.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Criticality Score Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signalio
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/ossf/criticality_score/internal/collector/signal"
+)
+
+type textWriter struct {
+	w                  io.Writer
+	fields             []string
+	firstRecordWritten bool
+
+	// Prevents concurrent writes to w.
+	mu sync.Mutex
+}
+
+func TextWriter(w io.Writer, emptySets []signal.Set, extra ...string) Writer {
+	return &textWriter{
+		w:      w,
+		fields: fieldsFromSignalSets(emptySets, extra),
+	}
+}
+
+// WriteSignals implements the Writer interface.
+func (w *textWriter) WriteSignals(signals []signal.Set, extra ...Field) error {
+	values, err := marshalToMap(signals, extra...)
+	if err != nil {
+		return err
+	}
+	return w.writeRecord(values)
+}
+
+func (w *textWriter) writeRecord(values map[string]string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Output a newline between records if this isn't the first record.
+	if w.firstRecordWritten {
+		_, err := fmt.Fprintln(w.w, "")
+		if err != nil {
+			return err
+		}
+	} else {
+		w.firstRecordWritten = true
+	}
+
+	for _, field := range w.fields {
+		val := values[field]
+		_, err := fmt.Fprintf(w.w, "%s: %s\n", field, val)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/signalio/type.go
+++ b/internal/signalio/type.go
@@ -27,6 +27,7 @@ type WriterType int
 const (
 	WriterTypeCSV = WriterType(iota)
 	WriterTypeJSON
+	WriterTypeText
 )
 
 var ErrorUnknownWriterType = errors.New("unknown writer type")
@@ -47,6 +48,8 @@ func (t WriterType) MarshalText() ([]byte, error) {
 		return []byte("csv"), nil
 	case WriterTypeJSON:
 		return []byte("json"), nil
+	case WriterTypeText:
+		return []byte("text"), nil
 	default:
 		return []byte{}, ErrorUnknownWriterType
 	}
@@ -59,6 +62,8 @@ func (t *WriterType) UnmarshalText(text []byte) error {
 		*t = WriterTypeCSV
 	case bytes.Equal(text, []byte("json")):
 		*t = WriterTypeJSON
+	case bytes.Equal(text, []byte("text")):
+		*t = WriterTypeText
 	default:
 		return ErrorUnknownWriterType
 	}
@@ -73,6 +78,8 @@ func (t *WriterType) New(w io.Writer, emptySets []signal.Set, extra ...string) W
 		return CSVWriter(w, emptySets, extra...)
 	case WriterTypeJSON:
 		return JSONWriter(w)
+	case WriterTypeText:
+		return TextWriter(w, emptySets, extra...)
 	default:
 		return nil
 	}


### PR DESCRIPTION
To make the command line tool more legible, and to improve feature parity with the Python implementation this change adds a "text" format of the style:

key: value

This format is now the default for the `criticality_score` tool as well.


Additionally, some minor doc improvements were made to cover this change and the scoring configuration.


Signed-off-by: Caleb Brown <calebbrown@google.com>