### PR TITLE
Can't have underscores in kubectl secrets.

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -84,9 +84,9 @@ kubectl create secret generic github --from-literal=token=$GITHUB_AUTH_TOKENS
 Updating Staging GitHub access tokens:
 
 ```shell
-kubectl create secret generic github_staging --from-literal=token=$GITHUB_AUTH_TOKENS
+kubectl create secret generic github-staging --from-literal=token=$GITHUB_AUTH_TOKENS
 ```
 
-**Note:** `github` and `github_staging` must be disjoint sets of GitHub
+**Note:** `github` and `github-staging` must be disjoint sets of GitHub
 personal access tokens. If they share tokens one environment may starve the
 other.

--- a/infra/envs/staging/auth_secret_key.yaml
+++ b/infra/envs/staging/auth_secret_key.yaml
@@ -25,5 +25,5 @@ spec:
         - name: GITHUB_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
-              name: github_staging
+              name: github-staging
               key: token


### PR DESCRIPTION
Signed-off-by: Caleb Brown <calebbrown@google.com>