### PR TITLE
Fix some minor bugs with the deploy config.

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -53,10 +53,11 @@ For Kustomize (fast):
 kubectl kustomize ./infra/envs/{staging,prod}
 ```
 
-For Skaffold (must be run from repo root):
+For Skaffold :
 
 ```shell
-skaffold render -f ./infra/skaffold.yaml --offline -p {staging,prod}
+cd infra && \
+  skaffold render -f ./skaffold.yaml --offline -p {staging,prod}
 ```
 
 ### Kubernetes Information

--- a/infra/skaffold.yaml
+++ b/infra/skaffold.yaml
@@ -19,13 +19,13 @@ profiles:
     deploy:
       kustomize:
         paths:
-          - infra/envs/staging
+          - envs/staging
         flags:
-          apply: ['--prune', '-l', 'managed-by-kustomize="true"']
+          apply: ['--prune', '-l', 'managed-by-kustomize=true']
   - name: prod
     deploy:
       kustomize:
         paths:
-          - infra/envs/prod
+          - envs/prod
         flags:
-          apply: ['--prune', '-l', 'managed-by-kustomize="true"']
+          apply: ['--prune', '-l', 'managed-by-kustomize=true']


### PR DESCRIPTION
- Cloud Deploy and skaffold want paths relative to the config.
- Unquote the value of the label so it parses correctly.

Signed-off-by: Caleb Brown <calebbrown@google.com>