### PR TITLE
Fixed lint warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
   enable:
     - asciicheck
     #- bodyclose  # Temporarily disabled.
-    - deadcode
     - depguard
     - dogsled
     #- errcheck  # Temporarily disabled.
@@ -59,7 +58,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
       #- wrapcheck
 linters-settings:


### PR DESCRIPTION
- fixed the following lint issues:
```
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>