### PR TITLE
Add the Git commit ID to the data produced by the worker.

### DIFF
--- a/cmd/collect_signals/Dockerfile
+++ b/cmd/collect_signals/Dockerfile
@@ -22,7 +22,7 @@ COPY . ./
 FROM base AS collect_signals
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 go build ./cmd/collect_signals
+RUN CGO_ENABLED=0 go build -buildvcs ./cmd/collect_signals
 RUN chmod -R 0775 /src/config/scorer/*
 
 FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684

--- a/cmd/collect_signals/main.go
+++ b/cmd/collect_signals/main.go
@@ -91,6 +91,11 @@ func main() {
 	}
 	defer logger.Sync()
 
+	// Embed the commitID with all log messages.
+	if commitID != "" {
+		logger = logger.With(zap.String("commit_id", commitID))
+	}
+
 	// Extract the GCP project ID.
 	gcpProjectID, err := config.GetProjectID()
 	if err != nil {

--- a/cmd/collect_signals/vcs.go
+++ b/cmd/collect_signals/vcs.go
@@ -20,6 +20,8 @@ import (
 
 const commitIDKey = "vcs.revision"
 
+var commitID = getCommitID()
+
 // getCommitID returns the vcs commit ID embedded in the binary when the
 // -buildvcs flag is set while building.
 func getCommitID() string {

--- a/cmd/collect_signals/vcs.go
+++ b/cmd/collect_signals/vcs.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Criticality Score Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"runtime/debug"
+)
+
+const commitIDKey = "vcs.revision"
+
+// getCommitID returns the vcs commit ID embedded in the binary when the
+// -buildvcs flag is set while building.
+func getCommitID() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	for _, setting := range info.Settings {
+		if setting.Key == commitIDKey {
+			return setting.Value
+		}
+	}
+
+	return ""
+}

--- a/cmd/collect_signals/worker.go
+++ b/cmd/collect_signals/worker.go
@@ -39,7 +39,6 @@ type collectWorker struct {
 func (w *collectWorker) Process(ctx context.Context, req *data.ScorecardBatchRequest, bucketURL string) error {
 	filename := worker.ResultFilename(req)
 	jobTime := req.GetJobTime().AsTime()
-	commitID := getCommitID()
 
 	// Prepare the logger with identifiers for the shard and job.
 	logger := w.logger.With(
@@ -47,9 +46,6 @@ func (w *collectWorker) Process(ctx context.Context, req *data.ScorecardBatchReq
 		zap.Time("job_time", jobTime),
 		zap.String("filename", filename),
 	)
-	if commitID != "" {
-		logger = logger.With(zap.String("commit_id", commitID))
-	}
 	logger.Info("Processing shard")
 
 	// Prepare the output writer

--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -64,10 +64,10 @@ $ export GITHUB_TOKEN=ghp_abc,ghp_123
 BigQuery access requires the "BigQuery User" (`roles/bigquery.user`) role added
 to the account used, or be an "Owner".
 
-##### Option 1: `gcloud login`
+##### Option 1: `gcloud auth login`
 
-This option is useful during development. Run `gcloud login --update-adc` to
-login to GCP and prepare application default credentials.
+This option is useful during development. Run `gcloud auth login --update-adc`
+to login to GCP and prepare application default credentials.
 
 ##### Option 2: GCE Service Worker
 


### PR DESCRIPTION
Including the Git commit ID with each record ensures that someone can easily identify which version of the code was used to produce the given result.

Signed-off-by: Caleb Brown <calebbrown@google.com>