### PR TITLE
Ensure deps.dev data is fresh for each run of Criticality Score

### DIFF
--- a/cmd/collect_signals/worker.go
+++ b/cmd/collect_signals/worker.go
@@ -39,6 +39,7 @@ type collectWorker struct {
 func (w *collectWorker) Process(ctx context.Context, req *data.ScorecardBatchRequest, bucketURL string) error {
 	filename := worker.ResultFilename(req)
 	jobTime := req.GetJobTime().AsTime()
+	jobID := jobTime.Format("20060102_150405")
 
 	// Prepare the logger with identifiers for the shard and job.
 	logger := w.logger.With(
@@ -83,7 +84,7 @@ func (w *collectWorker) Process(ctx context.Context, req *data.ScorecardBatchReq
 			repoLogger.With(zap.Error(err)).Warn("Failed to parse repo URL")
 			continue
 		}
-		ss, err := w.c.Collect(ctx, u)
+		ss, err := w.c.Collect(ctx, u, jobID)
 		if err != nil {
 			if errors.Is(err, collector.ErrUncollectableRepo) {
 				repoLogger.With(zap.Error(err)).Warn("Repo is uncollectable")

--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -126,7 +126,12 @@ fail.
 #### deps.dev Collection Flags
 
 - `-depsdev-disable` disables the collection of signals from deps.dev.
-- `-depsdev-dataset string` the BigQuery dataset name to use. Default is `depsdev_analysis`.
+- `-depsdev-dataset string` the BigQuery dataset name to use. Default is
+  `depsdev_analysis`.
+- `-depsdev-expiration hours` the default time-to-live or expiration for tables
+  created in the BigQuery dataset. New tables will be deleted after this
+  period. Expiration times on existing tables in the dataset won't be changed.
+  Default is `0` (no expiration).
 
 #### Scoring flags
 

--- a/cmd/criticality_score/main.go
+++ b/cmd/criticality_score/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -42,6 +43,7 @@ var (
 	gcpProjectFlag        = flag.String("gcp-project-id", "", "the Google Cloud Project ID to use. Auto-detects by default.")
 	depsdevDisableFlag    = flag.Bool("depsdev-disable", false, "disables the collection of signals from deps.dev.")
 	depsdevDatasetFlag    = flag.String("depsdev-dataset", collector.DefaultGCPDatasetName, "the BigQuery dataset name to use.")
+	depsdevTTLFlag        = flag.Int("depsdev-expiration", 0, "the default expiration (`hours`) to use for deps.dev tables. No expiration by default.")
 	scoringDisableFlag    = flag.Bool("scoring-disable", false, "disables the generation of scores.")
 	scoringConfigFlag     = flag.String("scoring-config", "", "path to a YAML file for configuring the scoring algorithm.")
 	scoringColumnNameFlag = flag.String("scoring-column", "", "manually specify the name for the column used to hold the score.")
@@ -145,6 +147,7 @@ func main() {
 		collector.EnableAllSources(),
 		collector.GCPProject(*gcpProjectFlag),
 		collector.GCPDatasetName(*depsdevDatasetFlag),
+		collector.GCPDatasetTTL(time.Hour * time.Duration(*depsdevTTLFlag)),
 	}
 	if *depsdevDisableFlag {
 		opts = append(opts, collector.DisableSource(collector.SourceTypeDepsDev))

--- a/cmd/criticality_score/main.go
+++ b/cmd/criticality_score/main.go
@@ -194,7 +194,7 @@ func main() {
 		innerLogger := logger.With(zap.Int("worker", worker))
 		for u := range repos {
 			l := innerLogger.With(zap.String("url", u.String()))
-			ss, err := c.Collect(ctx, u)
+			ss, err := c.Collect(ctx, u, "")
 			if err != nil {
 				if errors.Is(err, collector.ErrUncollectableRepo) {
 					l.With(

--- a/infra/envs/prod/config.yaml
+++ b/infra/envs/prod/config.yaml
@@ -33,6 +33,7 @@ additional-params:
     log-env: gcp
     log-level: info
     dataset: ossf_criticality_score_depsdev
+    dataset-ttl-hours: 672 # 4 weeks
     scoring: enabled
     scoring-config: config/scorer/pike_depsdev.yml
     scoring-column-name: default_score

--- a/infra/envs/staging/config.yaml
+++ b/infra/envs/staging/config.yaml
@@ -33,6 +33,7 @@ additional-params:
     log-env: gcp
     log-level: info
     dataset: ossf_criticality_score_depsdev_staging
+    dataset-ttl-hours: 168 # 1 week
     scoring: enabled
     scoring-config: config/scorer/pike_depsdev.yml
     scoring-column-name: default_score

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -81,7 +81,7 @@ func New(ctx context.Context, logger *zap.Logger, opts ...Option) (*Collector, e
 		// deps.dev collection source has been disabled, so skip it.
 		logger.Warn("deps.dev signal source is disabled.")
 	} else {
-		ddsource, err := depsdev.NewSource(ctx, logger, c.config.gcpProject, c.config.gcpDatasetName)
+		ddsource, err := depsdev.NewSource(ctx, logger, c.config.gcpProject, c.config.gcpDatasetName, c.config.gcpDatasetTTL)
 		if err != nil {
 			return nil, fmt.Errorf("init deps.dev source: %w", err)
 		}

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -99,7 +99,10 @@ func (c *Collector) EmptySets() []signal.Set {
 }
 
 // Collect gathers and returns all the signals for the given project repo url.
-func (c *Collector) Collect(ctx context.Context, u *url.URL) ([]signal.Set, error) {
+//
+// An optional jobID can be specified which can be used by underlying sources to
+// manage caching. For simple usage this can be the empty string.
+func (c *Collector) Collect(ctx context.Context, u *url.URL, jobID string) ([]signal.Set, error) {
 	l := c.config.logger.With(zap.String("url", u.String()))
 
 	repo, err := c.resolver.Resolve(ctx, u)
@@ -116,7 +119,7 @@ func (c *Collector) Collect(ctx context.Context, u *url.URL) ([]signal.Set, erro
 	l = l.With(zap.String("canonical_url", repo.URL().String()))
 
 	l.Info("Collecting")
-	ss, err := c.registry.Collect(ctx, repo)
+	ss, err := c.registry.Collect(ctx, repo, jobID)
 	if err != nil {
 		return nil, fmt.Errorf("collecting project: %w", err)
 	}

--- a/internal/collector/config.go
+++ b/internal/collector/config.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-logr/zapr"
 	"github.com/ossf/scorecard/v4/clients/githubrepo/roundtripper"
@@ -72,6 +73,7 @@ type config struct {
 
 	gcpProject     string
 	gcpDatasetName string
+	gcpDatasetTTL  time.Duration
 
 	sourceStatuses      map[SourceType]sourceStatus
 	defaultSourceStatus sourceStatus
@@ -94,6 +96,7 @@ func makeConfig(ctx context.Context, logger *zap.Logger, opts ...Option) *config
 		gitHubHTTPClient:    defaultGitHubHTTPClient(ctx, logger),
 		gcpProject:          "",
 		gcpDatasetName:      DefaultGCPDatasetName,
+		gcpDatasetTTL:       time.Duration(0),
 	}
 
 	for _, opt := range opts {
@@ -173,5 +176,13 @@ func GCPProject(n string) Option {
 func GCPDatasetName(n string) Option {
 	return option(func(c *config) {
 		c.gcpDatasetName = n
+	})
+}
+
+// GCPDatasetTTL sets the time-to-live for tables created with GCP BigQuery
+// datasets.
+func GCPDatasetTTL(ttl time.Duration) Option {
+	return option(func(c *config) {
+		c.gcpDatasetTTL = ttl
 	})
 }

--- a/internal/collector/config_test.go
+++ b/internal/collector/config_test.go
@@ -17,6 +17,7 @@ package collector
 import (
 	"context"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zaptest"
 )
@@ -77,6 +78,14 @@ func TestGCPDatasetName(t *testing.T) {
 	c := makeTestConfig(t, GCPDatasetName(want))
 	if c.gcpDatasetName != want {
 		t.Fatalf("config.gcpDatasetName = %q, want %q", c.gcpDatasetName, want)
+	}
+}
+
+func TestGCPDatasetTTL(t *testing.T) {
+	want := time.Duration(24) * time.Hour
+	c := makeTestConfig(t, GCPDatasetTTL(want))
+	if c.gcpDatasetTTL != want {
+		t.Fatalf("config.gcpDatasetTTL = %q, want %q", c.gcpDatasetTTL, want)
 	}
 }
 

--- a/internal/collector/depsdev/dependents.go
+++ b/internal/collector/depsdev/dependents.go
@@ -46,7 +46,7 @@ AS
   WHERE d.SnapshotAt = @part
   GROUP BY Name, Version, System;
 
-CREATE TABLE ` + "`{{.ProjectID}}.{{.DatasetName}}.{{.TableName}}`" + `
+CREATE TABLE IF NOT EXISTS ` + "`{{.ProjectID}}.{{.DatasetName}}.{{.TableName}}`" + `
 AS
 WITH pvp AS (
     SELECT System, Name, Version, ProjectName, ProjectType

--- a/internal/collector/depsdev/dependents.go
+++ b/internal/collector/depsdev/dependents.go
@@ -103,8 +103,8 @@ type dependents struct {
 	datasetTTL   time.Duration
 }
 
-func (c *dependents) generateQuery(temp string, tableName string) string {
-	t := template.Must(template.New("query").Parse(temp))
+func (c *dependents) generateQuery(queryTemplate, tableName string) string {
+	t := template.Must(template.New("query").Parse(queryTemplate))
 	var b bytes.Buffer
 	t.Execute(&b, struct {
 		ProjectID   string

--- a/internal/collector/depsdev/source.go
+++ b/internal/collector/depsdev/source.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/url"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/bigquery"
 	"go.uber.org/zap"
@@ -75,7 +76,7 @@ func (c *depsDevSource) Get(ctx context.Context, r projectrepo.Repo) (signal.Set
 // TODO add options to configure the dataset:
 //   - force dataset re-creation (-update-strategy = always,stale,weekly,monthly,never)
 //   - force dataset destruction (-depsdev-destroy-data)
-func NewSource(ctx context.Context, logger *zap.Logger, projectID, datasetName string) (signal.Source, error) {
+func NewSource(ctx context.Context, logger *zap.Logger, projectID, datasetName string, datasetTTL time.Duration) (signal.Source, error) {
 	if projectID == "" {
 		projectID = bigquery.DetectProjectID
 	}
@@ -86,7 +87,7 @@ func NewSource(ctx context.Context, logger *zap.Logger, projectID, datasetName s
 	// Set the location
 	gcpClient.Location = defaultLocation
 
-	dependents, err := NewDependents(ctx, gcpClient, logger, datasetName)
+	dependents, err := NewDependents(ctx, gcpClient, logger, datasetName, datasetTTL)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/collector/depsdev/source.go
+++ b/internal/collector/depsdev/source.go
@@ -54,14 +54,14 @@ func (c *depsDevSource) IsSupported(r projectrepo.Repo) bool {
 	return t != ""
 }
 
-func (c *depsDevSource) Get(ctx context.Context, r projectrepo.Repo) (signal.Set, error) {
+func (c *depsDevSource) Get(ctx context.Context, r projectrepo.Repo, jobID string) (signal.Set, error) {
 	var s depsDevSet
 	n, t := parseRepoURL(r.URL())
 	if t == "" {
 		return &s, nil
 	}
 	c.logger.With(zap.String("url", r.URL().String())).Debug("Fetching deps.dev dependent count")
-	deps, found, err := c.dependents.Count(ctx, n, t)
+	deps, found, err := c.dependents.Count(ctx, n, t, jobID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/collector/github/source.go
+++ b/internal/collector/github/source.go
@@ -30,7 +30,7 @@ func (rc *RepoSource) EmptySet() signal.Set {
 	return &signal.RepoSet{}
 }
 
-func (rc *RepoSource) Get(ctx context.Context, r projectrepo.Repo) (signal.Set, error) {
+func (rc *RepoSource) Get(ctx context.Context, r projectrepo.Repo, _ string) (signal.Set, error) {
 	ghr, ok := r.(*repo)
 	if !ok {
 		return nil, errors.New("project is not a github project")
@@ -91,7 +91,7 @@ func (ic *IssuesSource) EmptySet() signal.Set {
 	return &signal.IssuesSet{}
 }
 
-func (ic *IssuesSource) Get(ctx context.Context, r projectrepo.Repo) (signal.Set, error) {
+func (ic *IssuesSource) Get(ctx context.Context, r projectrepo.Repo, _ string) (signal.Set, error) {
 	ghr, ok := r.(*repo)
 	if !ok {
 		return nil, errors.New("project is not a github project")

--- a/internal/collector/githubmentions/source.go
+++ b/internal/collector/githubmentions/source.go
@@ -59,7 +59,7 @@ func (c *Source) IsSupported(r projectrepo.Repo) bool {
 	return true
 }
 
-func (c *Source) Get(ctx context.Context, r projectrepo.Repo) (signal.Set, error) {
+func (c *Source) Get(ctx context.Context, r projectrepo.Repo, _ string) (signal.Set, error) {
 	s := &mentionSet{}
 	if c, err := c.githubSearchTotalCommitMentions(ctx, r.URL()); err != nil {
 		return nil, err

--- a/internal/collector/registry.go
+++ b/internal/collector/registry.go
@@ -103,11 +103,14 @@ func (r *registry) EmptySets() []signal.Set {
 }
 
 // Collect will collect all the signals for the given repo.
-func (r *registry) Collect(ctx context.Context, repo projectrepo.Repo) ([]signal.Set, error) {
+//
+// An optinal jobID can be specified which is used by some sources for managing
+// caches.
+func (r *registry) Collect(ctx context.Context, repo projectrepo.Repo, jobID string) ([]signal.Set, error) {
 	cs := r.sourcesForRepository(repo)
 	var ss []signal.Set
 	for _, c := range cs {
-		s, err := c.Get(ctx, repo)
+		s, err := c.Get(ctx, repo, jobID)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/collector/signal/source.go
+++ b/internal/collector/signal/source.go
@@ -29,9 +29,12 @@ type Source interface {
 	// IsSupported returns true if the Source supports the supplied Repo.
 	IsSupported(projectrepo.Repo) bool
 
-	// Get gathers and returns a Set of signals for the given project repo.
+	// Get gathers and returns a Set of signals for the given project repo r.
+	//
+	// An optional string jobID can be specified and may be used by the Source
+	// to manage caches related to a collection run.
 	//
 	// An error is returned if it is unable to successfully gather the signals,
 	// or if the context is cancelled.
-	Get(context.Context, projectrepo.Repo) (Set, error)
+	Get(ctx context.Context, r projectrepo.Repo, jobID string) (Set, error)
 }


### PR DESCRIPTION
This PR ensures the deps.dev data is always fresh.

1. Introduce "IF NOT EXISTS" to the table generation so that if more than one worker attempts to create the table none of them fail (one will create the table, the others will exit without an error)
1. Add support for dataset table expiration. This allows old/stale tables to be automatically cleaned up by GCP avoiding unlimited growth of tables.
1. Introduce a "jobID" to collection to allow for caching across sources during runs.
1. Use "jobID" in the depsdev source
    - table creation is now done during `Count`
    - stores a last usage cache to avoid reattempting to check if the table exists, etc