### PR TITLE
Included Docker File for Scorer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,11 @@ format:  ## Run formatter
 format: $(GOFUMPT)
 	$(GOFUMPT) -w -l .
 
-docker-targets = build/docker/enumerate-github build/docker/criticality-score build/docker/collect-signals build/docker/csv-transfer
+docker-targets = build/docker/enumerate-github build/docker/criticality-score build/docker/collect-signals build/docker/csv-transfer build/docker/scorer
 .PHONY: build/docker $(docker-targets)
 build/docker: $(docker-targets)  ## Build all docker targets
+build/docker/scorer:
+	DOCKER_BUILDKIT=1 docker build . -f cmd/scorer/Dockerfile --tag $(IMAGE_NAME)-scorer
 build/docker/collect-signals:
 	DOCKER_BUILDKIT=1 docker build . -f cmd/collect_signals/Dockerfile --tag $(IMAGE_NAME)-collect-signals
 build/docker/criticality-score:

--- a/cmd/scorer/Dockerfile
+++ b/cmd/scorer/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2022 Criticality Score Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang@sha256:122f3484f844467ebe0674cf57272e61981770eb0bc7d316d1f0be281a88229f AS base
+WORKDIR /src
+ENV CGO_ENABLED=0
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . ./
+
+FROM base AS scorer
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 go build ./cmd/scorer
+
+FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684
+COPY --from=scorer /src/scorer ./scorer
+ENTRYPOINT ["./scorer"]


### PR DESCRIPTION
It is important to include a Dockerfile with a command-line interface (Scorer) project for the following reasons:

* Reproducibility: A Dockerfile allows others to easily build the same environment in which the Scorer was developed and tested. This ensures that the Scorer will behave consistently across different systems.
* Portability: With a Dockerfile, users can run the Scorer on any system that has Docker installed, regardless of the underlying operating system or dependencies.
* Collaboration: A Dockerfile allows other developers to easily contribute to the Scorer project by providing a consistent and well-defined environment for development and testing.

In summary, including a Dockerfile with a CLI project makes it easier to use, test, and collaborate on the project, and ensures that the CLI will behave consistently across different systems.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>