### PR TITLE
Removed GlobalRegistry from registry.go

### DIFF
--- a/internal/scorer/algorithm/registry.go
+++ b/internal/scorer/algorithm/registry.go
@@ -16,9 +16,6 @@ package algorithm
 
 import "fmt"
 
-// GlobalRegistry is the global, application wide, registry for all algorithms.
-var GlobalRegistry = NewRegistry()
-
 // Registry is used to map a name to a Factory that creates Algorithm instances
 // for the given name.
 type Registry struct {
@@ -54,14 +51,4 @@ func (r *Registry) NewAlgorithm(name string, inputs []*Input) (Algorithm, error)
 		return nil, fmt.Errorf("unknown algorithm %s", name)
 	}
 	return f(inputs)
-}
-
-// Register calls Register on the GlobalRegistry.
-func Register(name string, f Factory) {
-	GlobalRegistry.Register(name, f)
-}
-
-// NewAlgorithm calls NewAlgorithm on the GlobalRegsitry.
-func NewAlgorithm(name string, inputs []*Input) (Algorithm, error) {
-	return GlobalRegistry.NewAlgorithm(name, inputs)
 }

--- a/internal/scorer/algorithm/wam/wam.go
+++ b/internal/scorer/algorithm/wam/wam.go
@@ -46,7 +46,3 @@ func (p *WeighetedArithmeticMean) Score(record map[string]float64) float64 {
 	}
 	return s / totalWeight
 }
-
-func init() {
-	algorithm.Register("weighted_arithmetic_mean", New)
-}

--- a/internal/scorer/algorithm/wam/wam.go
+++ b/internal/scorer/algorithm/wam/wam.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The package wam implements the Weighted Arithmetic Mean, which forms the
+// Package wam implements the Weighted Arithmetic Mean, which forms the
 // basis of Rob Pike's criticality score algorithm as documented in
 // Quantifying_criticality_algorithm.pdf.
 package wam
@@ -20,6 +20,8 @@ package wam
 import (
 	"github.com/ossf/criticality_score/internal/scorer/algorithm"
 )
+
+const Name = "weighted_arithmetic_mean"
 
 type WeighetedArithmeticMean struct {
 	inputs []*algorithm.Input

--- a/internal/scorer/config.go
+++ b/internal/scorer/config.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/ossf/criticality_score/internal/scorer/algorithm"
+	"github.com/ossf/criticality_score/internal/scorer/algorithm/wam"
 )
 
 type Condition struct {
@@ -137,6 +138,7 @@ func LoadConfig(r io.Reader) (*Config, error) {
 // nil will be returned if the algorithm cannot be returned.
 func (c *Config) Algorithm() (algorithm.Algorithm, error) {
 	var inputs []*algorithm.Input
+	r := algorithm.NewRegistry()
 	for _, i := range c.Inputs {
 		input, err := i.ToAlgorithmInput()
 		if err != nil {
@@ -144,5 +146,7 @@ func (c *Config) Algorithm() (algorithm.Algorithm, error) {
 		}
 		inputs = append(inputs, input)
 	}
-	return algorithm.NewAlgorithm(c.Name, inputs)
+
+	r.Register("weighted_arithmetic_mean", wam.New)
+	return r.NewAlgorithm(c.Name, inputs)
 }

--- a/internal/scorer/config.go
+++ b/internal/scorer/config.go
@@ -147,6 +147,6 @@ func (c *Config) Algorithm() (algorithm.Algorithm, error) {
 		inputs = append(inputs, input)
 	}
 
-	r.Register("weighted_arithmetic_mean", wam.New)
+	r.Register(wam.Name, wam.New)
 	return r.NewAlgorithm(c.Name, inputs)
 }


### PR DESCRIPTION
Removed the `GlobalRegisty` variable from `internal/scorer/algorithm/registry.go` because it isn't good practice to use global variables. I was able to remove `GlobalRegistry` because the only places any function in `registry.go` was being used was in `wam.go` and `config.go`.

The `Register()` function (From `registry.go`) was only being used in the `init()` function (From `wam.go`). The `NewALgorithm()` function (From `registry.go`) was only being used in the `Algorithm()` function (From `config.go`). Since those were the only places any function from `registry.go` was being used externaly I created a `NewRegistry()` in `Algorithm()` and then registered it, and returned `r.NewAlgorithm()`.

Because of creating a `NewRegistry()` and registering it in `Algorithm` I removed the `init()` function in `wam.go` because it wasn't being used. I also removed the `Register()` and `NewAlgorithm()` functions from `registry.go` because they weren't being used. I also removed `GlobalRegisty`.

A key motivation for this decision was to eliminate the `init()` function, due to the considerations outlined in Peter Bourgon's blog post, "Theory of Modern Go" (https://peter.bourgon.org/blog/2017/06/09/theory-of-modern-go.html).

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>