### PR TITLE
Refactored internal/collector/depsdev/source

### DIFF
--- a/internal/collector/depsdev/source.go
+++ b/internal/collector/depsdev/source.go
@@ -16,6 +16,7 @@ package depsdev
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -28,8 +29,7 @@ import (
 )
 
 const (
-	defaultLocation    = "US"
-	DefaultDatasetName = "depsdev_analysis"
+	defaultLocation = "US"
 )
 
 type depsDevSet struct {
@@ -37,7 +37,7 @@ type depsDevSet struct {
 }
 
 func (s *depsDevSet) Namespace() signal.Namespace {
-	return signal.Namespace("depsdev")
+	return "depsdev"
 }
 
 type depsDevSource struct {
@@ -63,7 +63,7 @@ func (c *depsDevSource) Get(ctx context.Context, r projectrepo.Repo, jobID strin
 	c.logger.With(zap.String("url", r.URL().String())).Debug("Fetching deps.dev dependent count")
 	deps, found, err := c.dependents.Count(ctx, n, t, jobID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch deps.dev dependent count: %w", err)
 	}
 	if found {
 		s.DependentCount.Set(deps)
@@ -82,14 +82,14 @@ func NewSource(ctx context.Context, logger *zap.Logger, projectID, datasetName s
 	}
 	gcpClient, err := bigquery.NewClient(ctx, projectID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create bigquery client: %w", err)
 	}
 	// Set the location
 	gcpClient.Location = defaultLocation
 
 	dependents, err := NewDependents(ctx, gcpClient, logger, datasetName, datasetTTL)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create deps.dev dependents: %w", err)
 	}
 
 	return &depsDevSource{


### PR DESCRIPTION
- `DefaultDatasetName` wasn't used, so I removed it.
- I also replaced all of the `return err` with `return fmt.Errorf()` because it's considered good practice in Go to use `fmt.Errorf()` instead of just returning `err` as it provides more informative error messages. The `fmt.Errorf()` function formats a string into an error, allowing for added context and information that can aid in debugging and troubleshooting. On the other hand, returning just `err` without any extra information can make it harder to comprehend the error's cause and solution. Furthermore, using a formatted error message enhances error handling and debugging consistency.

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>