### PR TITLE
Included Wrapcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,9 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
-  new-from-rev: ""
+  # Exclude previously existing issues from the wrapcheck report
+  new: true
+  new-from-rev: HEAD
 linters:
   disable-all: true
   enable:
@@ -59,7 +61,7 @@ linters:
     - unparam
     - unused
     - whitespace
-      #- wrapcheck
+    - wrapcheck
 linters-settings:
   errcheck:
     check-type-assertions: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ issues:
   # Set to 0 to disable.
   # Default: 3
   max-same-issues: 0
-  # Exclude previously existing issues from the wrapcheck report
+  # Exclude previously existing issues from the report
   new: true
   new-from-rev: HEAD
 linters:


### PR DESCRIPTION
Currently, a lot of errors that are returned are just returning the error and not giving any description to what the error is when debugging (i.e. `return err`). A solution to this is to use the golang linter for wrapcheck.

- Included the wrapcheck linter
- Updated settings to ignore previous wrapcheck issues

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>