### PR TITLE
Switch back to @latest now that we have tagged the most recent Go code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ open source project:
 The program only requires one argument to run, the name of the repo:
 
 ```shell
-$ go install github.com/ossf/criticality_score/cmd/criticality_score@main
+$ go install github.com/ossf/criticality_score/cmd/criticality_score@latest
 
 $ criticality_score github.com/kubernetes/kubernetes
 repo.name: kubernetes


### PR DESCRIPTION
To solve #288, revert the change to use @main introduced in PR #320 now that we have v2.0.0 tagged.