### PR TITLE
Fix broken provenance generation - workflow must use tag.

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -1,4 +1,4 @@
-name: binary-release
+name: Binary Release
 
 on:
   push:
@@ -52,7 +52,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@68bad40844440577b33778c9f29077a3388838e9
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.4.0
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true # upload to a new release


### PR DESCRIPTION
SLSA's GitHub Workflow can't be pinned to a commit id.

It requires the tag and a ref to work. This change fixes the workflow.