### PR TITLE
Update the infra to use different auth. Prod uses GH App auth.

### DIFF
--- a/infra/envs/base/kustomization.yaml
+++ b/infra/envs/base/kustomization.yaml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 resources:
-- auth.yaml
 - bq_transfer.yaml
 - controller.yaml
 - csv_transfer.yaml
@@ -38,10 +37,3 @@ images:
 - name: scorecard-bq-transfer
   newName: gcr.io/openssf/scorecard-bq-transfer
   newTag: 27cfe92ed356fdb5a398c919ad480817ea907808
-
-vars:
-- name: GITHUB_AUTH_SERVER
-  objref:
-    kind: Service
-    name: criticality-score-github-auth
-    apiVersion: v1

--- a/infra/envs/base/worker.yaml
+++ b/infra/envs/base/worker.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: criticality-score-batch-worker
 spec:
-  replicas: 10
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: worker
@@ -31,9 +31,6 @@ spec:
           image: collect-signals
           args: ["--config=/etc/criticality_score/config.yaml"]
           imagePullPolicy: Always
-          env:
-            - name: GITHUB_AUTH_SERVER
-              value: "$(GITHUB_AUTH_SERVER):80"
           resources:
             requests:
               memory: 5Gi

--- a/infra/envs/prod/github_auth.yaml
+++ b/infra/envs/prod/github_auth.yaml
@@ -15,15 +15,30 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: criticality-score-github-auth
+  name: criticality-score-batch-worker
 spec:
   template:
     spec:
       containers:
-      - name: github-auth-server
+      - name: worker
         env:
-        - name: GITHUB_AUTH_TOKEN
+        - name: GITHUB_APP_KEY_PATH
+          value: /etc/github/app_key
+        - name: GITHUB_APP_ID
           valueFrom:
             secretKeyRef:
-              name: github-staging
-              key: token
+              name: github
+              key: app_id
+        - name: GITHUB_APP_INSTALLATION_ID
+          valueFrom:
+            secretKeyRef:
+              name: github
+              key: installation_id
+        volumeMounts:
+        - name: github-app-key
+          mountPath: "/etc/github/"
+          readOnly: true
+      volumes:
+      - name: github-app-key
+        secret:
+          secretName: github

--- a/infra/envs/prod/kustomization.yaml
+++ b/infra/envs/prod/kustomization.yaml
@@ -25,3 +25,7 @@ configMapGenerator:
   behavior: replace
   files:
   - config.yaml
+
+# Patches customize the base configurations for the prod environment.
+patchesStrategicMerge:
+- github_auth.yaml

--- a/infra/envs/staging/github_auth.yaml
+++ b/infra/envs/staging/github_auth.yaml
@@ -12,46 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
-metadata:
-  name: criticality-score-github-auth
-spec:
-  selector:
-    app.kubernetes.io/name: github-auth-server
-  type: ClusterIP
-  ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 8080
----
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: criticality-score-github-auth
+  name: criticality-score-batch-worker
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: github-auth-server
   template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: github-auth-server
     spec:
       containers:
-      - name: github-auth-server
-        image: scorecard-github-server
-        imagePullPolicy: Always
+      - name: worker
         env:
         - name: GITHUB_AUTH_TOKEN
           valueFrom:
             secretKeyRef:
-              name: github
+              name: github-staging
               key: token
-  strategy:
-    type: "RollingUpdate"
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 0

--- a/infra/envs/staging/kustomization.yaml
+++ b/infra/envs/staging/kustomization.yaml
@@ -29,7 +29,7 @@ configMapGenerator:
 
 # Patches customize the base configurations for the staging environment.
 patchesStrategicMerge:
-- auth_secret_key.yaml
+- github_auth.yaml
 - worker_replicas.yaml
 - controller_schedule.yaml
 - csv_transfer_schedule.yaml

--- a/infra/envs/staging/worker_replicas.yaml
+++ b/infra/envs/staging/worker_replicas.yaml
@@ -17,4 +17,4 @@ kind: Deployment
 metadata:
   name: criticality-score-batch-worker
 spec:
-  replicas: 4
+  replicas: 1

--- a/infra/k8s/enumerate_github.yaml
+++ b/infra/k8s/enumerate_github.yaml
@@ -29,8 +29,11 @@ spec:
             image: gcr.io/openssf/criticality-score-enumerate-github:latest
             imagePullPolicy: Always
             env:
-            - name: GITHUB_AUTH_SERVER
-              value: "10.4.4.210:80"
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: enumerate-github-auth
+                  key: token
             - name: CRITICALITY_SCORE_LOG_ENV
               value: "gcp"
             - name: CRITICALITY_SCORE_OUTFILE


### PR DESCRIPTION
- GitHub App auth used for Prod collection
- Single explicit token used for GitHub enumation (App auth doesn't work due to IP allowlisting limits)
- Removes the use of the auth server