### PR TITLE
Add a -version flag

### DIFF
--- a/cmd/criticality_score/main.go
+++ b/cmd/criticality_score/main.go
@@ -49,6 +49,7 @@ var (
 	scoringConfigFlag     = flag.String("scoring-config", "", "path to a YAML file for configuring the scoring algorithm.")
 	scoringColumnNameFlag = flag.String("scoring-column", "", "manually specify the name for the column used to hold the score.")
 	workersFlag           = flag.Int("workers", 1, "the total number of concurrent workers to use.")
+	versionFlag           = flag.Bool("version", false, "display the version of this command.")
 	logLevel              = defaultLogLevel
 	logEnv                log.Env
 	formatType            signalio.WriterType
@@ -72,6 +73,12 @@ func initFlags() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	// Handle the version flag immediately. It's similar to -help.
+	if *versionFlag {
+		printVersion()
+		os.Exit(0)
+	}
 }
 
 // getScorer prepares a Scorer based on the flags passed to the command.

--- a/cmd/criticality_score/version.go
+++ b/cmd/criticality_score/version.go
@@ -1,0 +1,21 @@
+package main
+
+import "fmt"
+
+// These variables are populated by GoReleaser. They can be set manually on the
+// command line using -ldflags. For example:
+//
+//	go build -ldflags="-X 'main.version=x' -X 'main.date=y' -X 'main.commit=z'" ./cmd/criticality_score
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func printVersion() {
+	if version == "dev" {
+		fmt.Printf("dev build")
+	} else {
+		fmt.Printf("v%s (%s - %s)\n", version, date, commit)
+	}
+}


### PR DESCRIPTION
Fixes #381.

Uses goreleaser ldflags to populate the data (see https://goreleaser.com/cookbooks/using-main.version/)