### PR TITLE
Fix usage example url in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ go install github.com/ossf/criticality_score/cmd/criticality_score@latest
 $ export GITHUB_TOKEN=...         # requires a GitHub token to work
 $ gcloud auth login --update-adc  # optional, add -depsdev-disable to skip
 
-$ criticality_score -gcp-project-id=[your projectID] github.com/kubernetes/kubernetes
+$ criticality_score -gcp-project-id=[your projectID] https://github.com/kubernetes/kubernetes
 repo.name: kubernetes
 repo.url: https://github.com/kubernetes/kubernetes
 repo.language: Go


### PR DESCRIPTION
When the repo input is without the "https" part (only `github.com/kubernetes/kubernetes`), it throws `Repo cannot be collected` error message.