### PR TITLE
Ensure init is idempotent and doesn't overwrite repo list.

### DIFF
--- a/infra/images/init_collect_signals/init.sh
+++ b/infra/images/init_collect_signals/init.sh
@@ -32,6 +32,14 @@ echo "bucket url = $BUCKET_URL"
 echo "bucket prefix file = $BUCKET_PREFIX_FILE"
 echo "url data file = $OUTPUT_FILE"
 
+# Exit early if $OUTPUT_FILE already exists. This ensures $OUTPUT_FILE remains
+# stable across any restart. Since the file is created atomically we can be
+# confident that the file won't be corrupt or truncated.
+if [ -f "$OUTPUT_FILE" ]; then
+    echo "Exiting early. $OUTPUT_FILE already exists."
+    exit 0
+fi
+
 LATEST_PREFIX=`gsutil cat "$BUCKET_URL"/"$BUCKET_PREFIX_FILE"`
 echo "latest prefix = $LATEST_PREFIX"
 


### PR DESCRIPTION
When a pod is restarted an `initContainer` can be run again.

The [documentation](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#detailed-behavior) says:

> Because init containers can be restarted, retried, or re-executed, init container code should be idempotent. In particular, code that writes to files on EmptyDirs should be prepared for the possibility that an output file already exists.

This PR ensures that the collect_signals init script is idempotent so that the pod can be safely restarted.