### PR TITLE
Add GitHub error type to GraphQL error messages.

### DIFF
--- a/internal/githubapi/errors.go
+++ b/internal/githubapi/errors.go
@@ -72,7 +72,7 @@ func (e *GraphQLErrors) Error() string {
 	case 0:
 		panic("no errors found")
 	case 1:
-		return e.errors[0].Message
+		return fmt.Sprintf("%s (type: %s)", e.errors[0].Message, e.errors[0].Type)
 	default:
 		return fmt.Sprintf("%d GraphQL errors", len(e.errors))
 	}

--- a/internal/githubapi/errors_test.go
+++ b/internal/githubapi/errors_test.go
@@ -71,9 +71,9 @@ func TestGraphQLErrors_Error(t *testing.T) {
 		{
 			name: "one error",
 			errors: []GraphQLError{
-				{Message: "one"},
+				{Message: "one", Type: "A_TYPE"},
 			},
-			want: "one",
+			want: "one (type: A_TYPE)",
 		},
 		{
 			name: "more than one error",


### PR DESCRIPTION
This is to help fix error handling when new errors are encountered.