### PR TITLE
Add support for FORBIDDEN GraphQL responses and simplify errors.

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -32,7 +32,7 @@ import (
 	"github.com/ossf/criticality_score/internal/githubapi"
 )
 
-// ErrUncollectableRepo is the  error returned when there is a problem with
+// ErrUncollectableRepo is the error returned when there is a problem with
 // the repo url passed in to be collected.
 //
 // For example, the URL may point to an invalid repository host, or the URL
@@ -105,7 +105,8 @@ func (c *Collector) Collect(ctx context.Context, u *url.URL, jobID string) ([]si
 		case errors.Is(err, projectrepo.ErrNoRepoFound):
 			fallthrough
 		case errors.Is(err, projectrepo.ErrRepoInaccessible):
-			return nil, fmt.Errorf("%w (%s): %w", ErrUncollectableRepo, u, err)
+			// TODO: replace %v with %w after upgrading Go from 1.19 to 1.21
+			return nil, fmt.Errorf("%w (%s): %v", ErrUncollectableRepo, u, err)
 		default:
 			return nil, fmt.Errorf("resolving project: %w", err)
 		}

--- a/internal/collector/github/factory.go
+++ b/internal/collector/github/factory.go
@@ -46,9 +46,11 @@ func (f *factory) New(ctx context.Context, u *url.URL) (projectrepo.Repo, error)
 	}
 	if err := r.init(ctx); err != nil {
 		if errors.Is(err, githubapi.ErrGraphQLNotFound) {
-			return nil, fmt.Errorf("%w (%s): %w", projectrepo.ErrNoRepoFound, u, err)
+			// TODO: replace %v with %w after upgrading Go from 1.19 to 1.21
+			return nil, fmt.Errorf("%w (%s): %v", projectrepo.ErrNoRepoFound, u, err)
 		} else if errors.Is(err, githubapi.ErrGraphQLForbidden) {
-			return nil, fmt.Errorf("%w (%s): %w", projectrepo.ErrRepoInaccessible, u, err)
+			// TODO: replace %v with %w after upgrading Go from 1.19 to 1.21
+			return nil, fmt.Errorf("%w (%s): %v", projectrepo.ErrRepoInaccessible, u, err)
 		} else {
 			return nil, err
 		}

--- a/internal/collector/github/factory.go
+++ b/internal/collector/github/factory.go
@@ -46,7 +46,9 @@ func (f *factory) New(ctx context.Context, u *url.URL) (projectrepo.Repo, error)
 	}
 	if err := r.init(ctx); err != nil {
 		if errors.Is(err, githubapi.ErrGraphQLNotFound) {
-			return nil, fmt.Errorf("%w: %s", projectrepo.ErrNoRepoFound, u)
+			return nil, fmt.Errorf("%w (%s): %w", projectrepo.ErrNoRepoFound, u, err)
+		} else if errors.Is(err, githubapi.ErrGraphQLForbidden) {
+			return nil, fmt.Errorf("%w (%s): %w", projectrepo.ErrRepoInaccessible, u, err)
 		} else {
 			return nil, err
 		}

--- a/internal/collector/projectrepo/resolver.go
+++ b/internal/collector/projectrepo/resolver.go
@@ -23,11 +23,15 @@ import (
 
 // ErrNoFactoryFound is returned when there is no factory that can be used for
 // a given URL.
-var ErrNoFactoryFound = errors.New("factory not found")
+var ErrNoFactoryFound = errors.New("factory not found for url")
 
 // ErrNoRepoFound is returned when a factory cannot create a Repo for a given
 // URL.
 var ErrNoRepoFound = errors.New("repo not found")
+
+// ErrRepoInaccessible is returned when a the Repo may exist, but is unable to
+// access the repository for some reason.
+var ErrRepoInaccessible = errors.New("repo inaccessible")
 
 // Resolver is used to resolve a Repo url against a set of Factory instances
 // registered with the resolver.

--- a/internal/githubapi/errors.go
+++ b/internal/githubapi/errors.go
@@ -38,18 +38,35 @@ func ErrorResponseStatusCode(err error) int {
 	return e.Response.StatusCode
 }
 
-// ErrGraphQLNotFound is an error used to test when GitHub GraphQL query
-// returns a single error with the type "NOT_FOUND".
-//
-// It should be used with errors.Is.
-var ErrGraphQLNotFound = errors.New("GraphQL resource not found")
+var (
+	// ErrGraphQLNotFound is an error used to test when GitHub GraphQL query
+	// returns a single error with the type "NOT_FOUND".
+	//
+	// It should be used with errors.Is.
+	ErrGraphQLNotFound = errors.New("GraphQL resource not found")
 
-// gitHubGraphQLNotFoundType matches the NOT_FOUND type field returned
-// in GitHub's GraphQL errors.
-//
-// GraphQL errors are required to have a Message, and optional Path and
-// Locations. Type is a non-standard field available on GitHub's API.
-const gitHubGraphQLNotFoundType = "NOT_FOUND"
+	// ErrGraphQLForbidden is an error used to test when GitHub GraphQL query
+	// returns a single error with the type "FORBIDDEN".
+	//
+	// It should be used with errors.Is.
+	ErrGraphQLForbidden = errors.New("GraphQL access forbidden")
+)
+
+const (
+	// gitHubGraphQLNotFoundType matches the NOT_FOUND type field returned
+	// in GitHub's GraphQL errors.
+	//
+	// GraphQL errors are required to have a Message, and optional Path and
+	// Locations. Type is a non-standard field available on GitHub's API.
+	gitHubGraphQLNotFoundType = "NOT_FOUND"
+
+	// gitHubGraphQLForbiddenType matches the FORBIDDEN type field returned
+	// in GitHub's GraphQL errors.
+	//
+	// This error type is used when the authorization token has been blocked
+	// from accessing the repository. Usually due to an IP address block.
+	gitHubGraphQLForbiddenType = "FORBIDDEN"
+)
 
 // GraphQLError stores the error result from a GitHub GraphQL query.
 type GraphQLError struct {
@@ -97,6 +114,9 @@ func (e *GraphQLErrors) Errors() []GraphQLError {
 func (e *GraphQLErrors) Is(target error) bool {
 	if target == ErrGraphQLNotFound {
 		return len(e.errors) == 1 && e.HasType(gitHubGraphQLNotFoundType)
+	}
+	if target == ErrGraphQLForbidden {
+		return len(e.errors) == 1 && e.HasType(gitHubGraphQLForbiddenType)
 	}
 	return false
 }

--- a/internal/githubapi/errors_test.go
+++ b/internal/githubapi/errors_test.go
@@ -179,6 +179,22 @@ func TestGraphQLErrors_Is(t *testing.T) {
 			want:   false,
 		},
 		{
+			name: "target equals ErrGraphQLForbidden and returns true",
+			errors: []GraphQLError{
+				{Message: "one", Type: "FORBIDDEN"},
+			},
+			target: ErrGraphQLForbidden,
+			want:   true,
+		},
+		{
+			name: "target equals ErrGraphQLForbidden and returns false",
+			errors: []GraphQLError{
+				{Message: "one"},
+			},
+			target: ErrGraphQLForbidden,
+			want:   false,
+		},
+		{
 			name: "regular testcase",
 			errors: []GraphQLError{
 				{Message: "one"},
@@ -194,6 +210,16 @@ func TestGraphQLErrors_Is(t *testing.T) {
 				{Message: "three"},
 			},
 			target: ErrGraphQLNotFound,
+			want:   false,
+		},
+		{
+			name: "multiple errors with only one having the error type as 'FORBIDDEN'",
+			errors: []GraphQLError{
+				{Message: "one"},
+				{Message: "two", Type: "FORBIDDEN"},
+				{Message: "three"},
+			},
+			target: ErrGraphQLForbidden,
 			want:   false,
 		},
 	}


### PR DESCRIPTION
Handle {type: "FORBIDDEN"} GitHub GraphQL error responses that are returned when the App based authentication fails to access a repository due to GitHub org restrictions.

This change also simplifies some of the error handling, especially with multi-wrapped errors available in later versions of Go.