### PR TITLE
Fix the slightly incorrect docs for running go install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ open source project:
 ## Usage
 
 ```shell
-$ go install github.com/ossf/criticality_score/v2/cmd/criticality_score@latest
+$ go install github.com/ossf/criticality_score/cmd/criticality_score@latest
 
 $ export GITHUB_TOKEN=...         # requires a GitHub token to work
 $ gcloud auth login --update-adc  # optional, add -depsdev-disable to skip

--- a/cmd/criticality_score/README.md
+++ b/cmd/criticality_score/README.md
@@ -21,7 +21,7 @@ $ criticality_score \
 ## Install
 
 ```shell
-$ go install github.com/ossf/criticality_score/v2/cmd/criticality_score
+$ go install github.com/ossf/criticality_score/cmd/criticality_score@latest
 ```
 
 ## Usage

--- a/cmd/enumerate_github/README.md
+++ b/cmd/enumerate_github/README.md
@@ -19,7 +19,7 @@ $ enumerate_github \
 ## Install
 
 ```shell
-$ go install github.com/ossf/criticality_score/v2/cmd/enumerate_github
+$ go install github.com/ossf/criticality_score/cmd/enumerate_github@latest
 ```
 
 ## Usage

--- a/cmd/scorer/README.md
+++ b/cmd/scorer/README.md
@@ -17,7 +17,7 @@ $ scorer \
 ## Install
 
 ```shell
-$ go install github.com/ossf/criticality_score/v2/cmd/scorer
+$ go install github.com/ossf/criticality_score/cmd/scorer@latest
 ```
 
 ## Usage


### PR DESCRIPTION
After testing, the "/v2" should not be in the package URL during `go install`.

This change fixes the commands in the README.md files.