### PR TITLE
Update the secondary rate limit detector.

### DIFF
--- a/internal/githubapi/roundtripper.go
+++ b/internal/githubapi/roundtripper.go
@@ -135,7 +135,8 @@ func (s *strategies) SecondaryRateLimit(r *http.Response) (retry.RetryStrategy, 
 		zap.String("message", errorResponse.Message),
 	).Warn("Error response data")
 	if strings.HasSuffix(errorResponse.DocumentationURL, "#abuse-rate-limits") ||
-		strings.HasSuffix(errorResponse.DocumentationURL, "#secondary-rate-limits") {
+		strings.HasSuffix(errorResponse.DocumentationURL, "#secondary-rate-limits") ||
+		strings.HasSuffix(errorResponse.DocumentationURL, "#about-secondary-rate-limits") {
 		logger.Warn("Secondary rate limit hit")
 		return retry.RetryWithInitialDelay, nil
 	}

--- a/internal/githubapi/roundtripper_test.go
+++ b/internal/githubapi/roundtripper_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	testAbuseRateLimitDocURL     = "https://docs.github.com/en/rest/overview/resources-in-the-rest-api#abuse-rate-limits"
-	testSecondaryRateLimitDocURL = "https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits"
+	testSecondaryRateLimitDocURL = "https://docs.github.com/free-pro-team@latest/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits"
 )
 
 func newTestStrategies(t *testing.T) *strategies {


### PR DESCRIPTION
The JSON response for a 403 secondary rate limit now contains the doc_url:

https://docs.github.com/free-pro-team@latest/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits

This update handles this change.