### PR TITLE
Update base docker images.

### DIFF
--- a/cmd/collect_signals/Dockerfile
+++ b/cmd/collect_signals/Dockerfile
@@ -25,7 +25,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 go build -buildvcs ./cmd/collect_signals
 RUN chmod -R 0775 /src/config/scorer/*
 
-FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684
+FROM gcr.io/distroless/base:nonroot@sha256:fa5f94fa433728f8df3f63363ffc8dec4adcfb57e4d8c18b44bceccfea095ebc
 COPY --from=collect_signals /src/collect_signals ./collect_signals
 COPY --from=collect_signals /src/config/scorer/* ./config/scorer/
 ENTRYPOINT ["./collect_signals"]

--- a/cmd/criticality_score/Dockerfile
+++ b/cmd/criticality_score/Dockerfile
@@ -25,7 +25,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 go build ./cmd/criticality_score
 RUN chmod -R 0775 /src/config/scorer/*
 
-FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684
+FROM gcr.io/distroless/base:nonroot@sha256:fa5f94fa433728f8df3f63363ffc8dec4adcfb57e4d8c18b44bceccfea095ebc
 COPY --from=criticality_score /src/criticality_score ./criticality_score
 COPY --from=criticality_score /src/config/scorer/* ./config/scorer/
 ENTRYPOINT ["./criticality_score"]

--- a/cmd/csv_transfer/Dockerfile
+++ b/cmd/csv_transfer/Dockerfile
@@ -24,6 +24,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 go build ./cmd/csv_transfer
 
-FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684
+FROM gcr.io/distroless/base:nonroot@sha256:fa5f94fa433728f8df3f63363ffc8dec4adcfb57e4d8c18b44bceccfea095ebc
 COPY --from=csv_transfer /src/csv_transfer ./csv_transfer
 ENTRYPOINT ["./csv_transfer"]

--- a/cmd/enumerate_github/Dockerfile
+++ b/cmd/enumerate_github/Dockerfile
@@ -24,6 +24,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 go build ./cmd/enumerate_github
 
-FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684
+FROM gcr.io/distroless/base:nonroot@sha256:fa5f94fa433728f8df3f63363ffc8dec4adcfb57e4d8c18b44bceccfea095ebc
 COPY --from=enumerate_github /src/enumerate_github ./enumerate_github
 ENTRYPOINT ["./enumerate_github"]

--- a/infra/images/init_collect_signals/Dockerfile
+++ b/infra/images/init_collect_signals/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:slim@sha256:134f1938136304884f2d3b7365162adb1ca06d0b86c599f15a4fe107b94f7950
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:slim@sha256:e151ce4405e7f71c1a2ba8921af99e83c6cb7d8c4fc5e49d94c2807889b57564
 
 # Add "yq" to the image so the YAML config can be read.
 RUN apt-get update -qqy && apt-get install -qqy yq

--- a/infra/images/init_collect_signals/Dockerfile
+++ b/infra/images/init_collect_signals/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:slim@sha256:3497ad3a1053bda2c99a766e8764dd27756fdaf84191dd1501405779688abf58
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:slim@sha256:134f1938136304884f2d3b7365162adb1ca06d0b86c599f15a4fe107b94f7950
 
 # Add "yq" to the image so the YAML config can be read.
 RUN apt-get update -qqy && apt-get install -qqy yq


### PR DESCRIPTION
Update the gcr.io/distroless/base:nonroot and gcr.io/google.com/cloudsdktool/google-cloud-cli:slim images to their latest tags