### PR TITLE
Return an empty result when no queries are provided in BatchQuery

### DIFF
--- a/internal/githubapi/batch.go
+++ b/internal/githubapi/batch.go
@@ -56,8 +56,7 @@ func constructBatchQuery[T any](queries map[string]string) (string, map[string]s
 func BatchQuery[T any](ctx context.Context, c *Client, queries map[string]string) (map[string]T, error) {
 	// TODO: an upper bound should be added
 	if len(queries) == 0 {
-		// TODO: consider just returning an empty result set rather than panicing.
-		panic("no query to run")
+		return map[string]T{}, nil
 	}
 
 	// Generate the query from the type T and the set of queries.


### PR DESCRIPTION
This PR changes the `BatchQuery` internal function to return an empty map when no queries are passed instead of panicking.