### PR TITLE
Use the search API to count issues

### DIFF
--- a/internal/collector/github/legacy/issues.go
+++ b/internal/collector/github/legacy/issues.go
@@ -16,6 +16,7 @@ package legacy
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/go-github/v47/github"
@@ -36,12 +37,18 @@ const (
 //
 // This count includes both issues and pull requests.
 func FetchIssueCount(ctx context.Context, c *githubapi.Client, owner, name string, state IssueState, lookback time.Duration) (int, error) {
-	opts := &github.IssueListByRepoOptions{
-		Since:       time.Now().UTC().Add(-lookback),
-		State:       string(state),
-		ListOptions: github.ListOptions{PerPage: 1}, // 1 result per page means LastPage is total number of records.
+	// The repo issues list endpoint uses cursor-based pagination, which does
+	// not expose the last page number, so the count comes from the search
+	// API's total_count instead.
+	since := time.Now().UTC().Add(-lookback)
+	query := fmt.Sprintf("repo:%s/%s updated:>=%s", owner, name, since.Format(time.RFC3339))
+	if state != IssueStateAll {
+		query = fmt.Sprintf("%s is:%s", query, state)
 	}
-	is, resp, err := c.Rest().Issues.ListByRepo(ctx, owner, name, opts)
+	opts := &github.SearchOptions{
+		ListOptions: github.ListOptions{PerPage: 1},
+	}
+	res, _, err := c.Rest().Search.Issues(ctx, query, opts)
 	// The API returns 5xx responses if there are too many issues.
 	if c := githubapi.ErrorResponseStatusCode(err); 500 <= c && c < 600 {
 		return MaxIssuesLimit, nil
@@ -49,10 +56,7 @@ func FetchIssueCount(ctx context.Context, c *githubapi.Client, owner, name strin
 	if err != nil {
 		return 0, err
 	}
-	if resp.NextPage == 0 {
-		return len(is), nil
-	}
-	return resp.LastPage, nil
+	return res.GetTotal(), nil
 }
 
 // FetchIssueCommentCount returns the total number of comments for a given repo


### PR DESCRIPTION
## Summary

Fixes #816.

The three legacy issue signals (`updated_issues_count`, `closed_issues_count`, and `issue_comment_frequency`) currently report 0 for every repository.

GitHub's repo issues list endpoint (`/repos/{owner}/{repo}/issues`) now uses cursor-based pagination: its `Link` header contains only a `rel="next"` entry with an opaque cursor, and no `rel="last"` entry. `FetchIssueCount` relied on requesting `per_page=1` and reading the total from the last page number, so it now always sees `LastPage == 0` and returns 0. Since `issue_comment_frequency` divides the comment count by the updated-issues count, it is zeroed as well.

This change counts issues with a single search API request instead, reading the exact `total_count` from the response. The original semantics are preserved:

- Both issues and pull requests are counted (search includes both by default, matching the list endpoint).
- Results are filtered on updated time within the lookback window (`updated:>=<timestamp>`), matching the list endpoint's `since` parameter.
- The closed state is expressed as `is:closed`, matching `state=closed` combined with `since` (closed-state items updated within the window).
- The 5xx fallback to `MaxIssuesLimit` is unchanged.

`FetchIssueCommentCount` is untouched. The comments endpoint still uses page-number pagination.

## Testing

- `make test` passes.
- `make lint` passes.
- Verified end to end against `camUrban/PteraSoftware` (a repo with recent issue activity): before this change the three signals were 0/0/0; after, they are 117/100/1.19, matching direct queries to the search API for the same 90-day window.
